### PR TITLE
Fix: Cloudinary upload + shipment document upload route wiring

### DIFF
--- a/Admin/src/pages/Shipment.jsx
+++ b/Admin/src/pages/Shipment.jsx
@@ -734,6 +734,11 @@ const Shipment = () => {
 
   const handleUploadDocument = async (inputRef) => {
     try {
+      if (!shipmentId) {
+        setDocError("Shipment not found.");
+        return;
+      }
+
       if (!newDocFile) {
         inputRef?.current?.click();
         return;
@@ -762,13 +767,23 @@ const Shipment = () => {
 
       setNewDocFile(null);
       setNewDocName("");
+      setNewDocUrl("");
+
+      if (mobileDocFileInputRef?.current) {
+        mobileDocFileInputRef.current.value = "";
+      }
+
+      if (desktopDocFileInputRef?.current) {
+        desktopDocFileInputRef.current.value = "";
+      }
     } catch (err) {
-      console.error(err);
+      console.error("❌ Error uploading document:", err.response?.data || err);
       setDocError(err?.response?.data?.message || "Failed to upload document.");
     } finally {
       setDocSaving(false);
     }
   };
+
   // ---------------- QUOTE: UI handlers ----------------
   const quoteTotals = useMemo(() => {
     return computeUiTotals(quoteForm.lineItems);
@@ -2549,7 +2564,13 @@ const Shipment = () => {
                 <input
                   ref={mobileDocFileInputRef}
                   type="file"
-                  onChange={(e) => setNewDocFile(e.target.files?.[0] || null)}
+                  onChange={(e) => {
+                    const file = e.target.files?.[0] || null;
+                    setNewDocFile(file);
+                    if (file && !newDocName.trim()) {
+                      setNewDocName(file.name);
+                    }
+                  }}
                   className="text-xs"
                 />
                 <div className="flex justify-end gap-2">
@@ -2643,7 +2664,13 @@ const Shipment = () => {
                 <input
                   ref={desktopDocFileInputRef}
                   type="file"
-                  onChange={(e) => setNewDocFile(e.target.files?.[0] || null)}
+                  onChange={(e) => {
+                    const file = e.target.files?.[0] || null;
+                    setNewDocFile(file);
+                    if (file && !newDocName.trim()) {
+                      setNewDocName(file.name);
+                    }
+                  }}
                   className="text-xs"
                 />
                 <div className="flex justify-end gap-2">

--- a/Backend/routes/shipment.js
+++ b/Backend/routes/shipment.js
@@ -12,6 +12,7 @@ const {
   deleteShipment,
   addTrackingEvent,
   addDocument,
+  uploadDocument,
   updateStatus,
   getDashboardStats,
   respondToQuote,
@@ -29,6 +30,7 @@ const {
 
 const { requireAuth, requireRole } = require("../middleware/auth");
 const { handleValidation } = require("../middleware/validate");
+const uploadShipmentDocument = require("../middleware/uploadShipmentDocument");
 const {
   validateObjectIdParam,
   validateTrackingEvent,
@@ -284,7 +286,7 @@ router.post(
 
 /**
  * @route   POST /shipments/:id/documents
- * @desc    Add document to shipment
+ * @desc    Add document to shipment by public URL
  * @access  Admin only
  */
 router.post(
@@ -295,6 +297,21 @@ router.post(
   validateDocument,
   handleValidation,
   addDocument,
+);
+
+/**
+ * @route   POST /shipments/:id/documents/upload
+ * @desc    Upload document file to shipment
+ * @access  Admin only
+ */
+router.post(
+  "/:id/documents/upload",
+  requireAuth,
+  requireRole("admin"),
+  validateObjectIdParam("id"),
+  handleValidation,
+  uploadShipmentDocument.single("file"),
+  uploadDocument,
 );
 
 /**


### PR DESCRIPTION
This PR completes the document upload pipeline:

- Added Cloudinary integration for file storage
- Fixed dotenv load order
- Added missing backend route: /shipments/:id/documents/upload
- Wired multer middleware for file upload
- Stabilized Admin upload flow (multiple uploads fix)

Result:
End-to-end file upload now works from Admin → Backend → Cloudinary → MongoDB