### PR TITLE
feat: public unsubscribe page and endpoint

### DIFF
--- a/Backend/controllers/marketing.js
+++ b/Backend/controllers/marketing.js
@@ -268,3 +268,37 @@ exports.uploadImage = async (req, res) => {
     return res.status(500).json({ message: "Image upload failed." });
   }
 };
+
+// -----------------------------------------------
+// GET /api/v1/marketing/unsubscribe?email=...
+// Public one-click unsubscribe — no auth required
+// -----------------------------------------------
+exports.publicUnsubscribe = async (req, res) => {
+  try {
+    const { email } = req.query;
+    if (!email) {
+      return res.status(400).json({ message: "Email is required." });
+    }
+
+    const subscriber = await Subscriber.findOne({ email: email.toLowerCase().trim() });
+
+    if (!subscriber) {
+      // Return success anyway — don't reveal whether email exists (GDPR)
+      return res.status(200).json({ message: "Unsubscribed successfully." });
+    }
+
+    if (subscriber.unsubscribed) {
+      return res.status(200).json({ message: "Already unsubscribed." });
+    }
+
+    subscriber.unsubscribed    = true;
+    subscriber.unsubscribedAt  = new Date();
+    await subscriber.save();
+
+    console.log(`✅ Public unsubscribe: ${email}`);
+    return res.status(200).json({ message: "Unsubscribed successfully." });
+  } catch (err) {
+    console.error("publicUnsubscribe error:", err);
+    return res.status(500).json({ message: "Server error." });
+  }
+};

--- a/Backend/routes/marketing.js
+++ b/Backend/routes/marketing.js
@@ -11,6 +11,7 @@ const {
   getCampaigns,
   getCampaign,
   postmarkWebhook,
+  publicUnsubscribe,
 } = require("../controllers/marketing");
 
 const { requireAuth, requireAdmin } = require("../middleware/auth");
@@ -35,5 +36,8 @@ router.get("/campaigns/:id", requireAuth, requireAdmin, getCampaign);
 
 // Postmark webhook — public, no auth (Postmark calls this)
 router.post("/webhooks/postmark", postmarkWebhook);
+
+// Public unsubscribe — no auth (linked from emails)
+router.get("/unsubscribe", publicUnsubscribe);
 
 module.exports = router;

--- a/BackgroundServices/EmailService/DripSequenceEmail.js
+++ b/BackgroundServices/EmailService/DripSequenceEmail.js
@@ -98,7 +98,7 @@ function buildTouch2Html(name) {
           <td style="background:#f9fafb;padding:20px 40px;border-top:1px solid #e5e7eb;">
             <p style="margin:0;font-size:12px;color:#9ca3af;">
               You are receiving this because you opted in to updates from Ellcworth Express.
-              <a href="https://ellcworth.com/unsubscribe" style="color:#9ca3af;">Unsubscribe</a>
+              <a href="https://ellcworth.com/unsubscribe?email=${encodeURIComponent(recipient.email)}" style="color:#9ca3af;">Unsubscribe</a>
             </p>
           </td>
         </tr>
@@ -191,7 +191,7 @@ function buildTouch3Html(name) {
           <td style="background:#f9fafb;padding:20px 40px;border-top:1px solid #e5e7eb;">
             <p style="margin:0;font-size:12px;color:#9ca3af;">
               You are receiving this because you opted in to updates from Ellcworth Express.
-              <a href="https://ellcworth.com/unsubscribe" style="color:#9ca3af;">Unsubscribe</a>
+              <a href="https://ellcworth.com/unsubscribe?email=${encodeURIComponent(recipient.email)}" style="color:#9ca3af;">Unsubscribe</a>
             </p>
           </td>
         </tr>

--- a/Frontend/src/App.jsx
+++ b/Frontend/src/App.jsx
@@ -16,6 +16,7 @@ import NewBooking from "@/pages/customer/NewBooking.jsx";
 import EditBooking from "@/pages/customer/EditBooking.jsx";
 import RequireCustomerAuth from "@/components/auth/RequireCustomerAuth.jsx";
 import ResetPassword from "@/pages/auth/ResetPassword.jsx";
+import Unsubscribe from "@/pages/public/Unsubscribe.jsx";
 
 const router = createBrowserRouter([
   {
@@ -31,6 +32,7 @@ const router = createBrowserRouter([
       // Auth
       { path: "login", element: <CustomerLogin /> },
       { path: "auth/reset-password/:token", element: <ResetPassword /> },
+      { path: "unsubscribe", element: <Unsubscribe /> },
 
       // Customer (protected)
       {

--- a/Frontend/src/pages/public/Unsubscribe.jsx
+++ b/Frontend/src/pages/public/Unsubscribe.jsx
@@ -1,0 +1,110 @@
+import { useEffect, useState } from "react";
+import { useSearchParams, Link } from "react-router-dom";
+
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || "http://localhost:8000";
+
+function Unsubscribe() {
+  const [searchParams] = useSearchParams();
+  const email = searchParams.get("email") || "";
+  const [status, setStatus] = useState("idle"); // idle | loading | success | error
+  const [message, setMessage] = useState("");
+
+  useEffect(() => {
+    if (!email) return;
+    setStatus("loading");
+    fetch(`${API_BASE_URL}/api/v1/marketing/unsubscribe?email=${encodeURIComponent(email)}`)
+      .then((r) => r.json())
+      .then((data) => {
+        setMessage(data.message || "Unsubscribed successfully.");
+        setStatus("success");
+      })
+      .catch(() => {
+        setMessage("Something went wrong. Please try again.");
+        setStatus("error");
+      });
+  }, [email]);
+
+  return (
+    <div className="bg-[#1A2930] min-h-[60vh] flex items-center justify-center px-4">
+      <div className="bg-white rounded-xl shadow-xl border border-[#9A9EAB]/40 px-8 py-10 max-w-md w-full text-center">
+
+        {/* Logo / brand mark */}
+        <div className="w-12 h-12 rounded-full bg-[#1A2930] flex items-center justify-center mx-auto mb-5">
+          <svg className="w-6 h-6 text-[#FFA500]" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+            <path strokeLinecap="round" strokeLinejoin="round" d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z" />
+          </svg>
+        </div>
+
+        {/* No email in URL */}
+        {!email && (
+          <>
+            <h1 className="text-xl font-semibold text-[#1A2930] mb-2">Unsubscribe</h1>
+            <p className="text-sm text-slate-600 mb-6">
+              No email address found in this link. Please use the unsubscribe link from your email.
+            </p>
+          </>
+        )}
+
+        {/* Loading */}
+        {email && status === "loading" && (
+          <>
+            <h1 className="text-xl font-semibold text-[#1A2930] mb-2">Processing…</h1>
+            <p className="text-sm text-slate-500">Please wait while we update your preferences.</p>
+            <div className="mt-6 flex justify-center">
+              <div className="w-6 h-6 border-2 border-[#1A2930] border-t-transparent rounded-full animate-spin" />
+            </div>
+          </>
+        )}
+
+        {/* Success */}
+        {status === "success" && (
+          <>
+            <div className="w-10 h-10 rounded-full bg-emerald-100 flex items-center justify-center mx-auto mb-4">
+              <svg className="w-5 h-5 text-emerald-600" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2.5}>
+                <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
+              </svg>
+            </div>
+            <h1 className="text-xl font-semibold text-[#1A2930] mb-2">You're unsubscribed</h1>
+            <p className="text-sm text-slate-600 mb-1">{email}</p>
+            <p className="text-sm text-slate-500 mb-6">
+              You won't receive any more marketing emails from Ellcworth Express.
+              Transactional emails about your shipments will continue as normal.
+            </p>
+          </>
+        )}
+
+        {/* Error */}
+        {status === "error" && (
+          <>
+            <div className="w-10 h-10 rounded-full bg-red-100 flex items-center justify-center mx-auto mb-4">
+              <svg className="w-5 h-5 text-red-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2.5}>
+                <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+              </svg>
+            </div>
+            <h1 className="text-xl font-semibold text-[#1A2930] mb-2">Something went wrong</h1>
+            <p className="text-sm text-slate-600 mb-6">{message}</p>
+          </>
+        )}
+
+        <div className="flex flex-col sm:flex-row gap-3 justify-center">
+          <Link to="/">
+            <button className="w-full sm:w-auto px-4 py-2 rounded-full text-sm font-semibold bg-[#1A2930] text-white hover:bg-[#FFA500] hover:text-[#1A2930] transition">
+              Back to Home
+            </button>
+          </Link>
+        </div>
+
+        <p className="text-xs text-slate-400 mt-6">
+          Changed your mind?{" "}
+          <a href="mailto:cs@ellcworth.com" className="text-[#FFA500] hover:underline">
+            Contact us
+          </a>{" "}
+          to resubscribe.
+        </p>
+
+      </div>
+    </div>
+  );
+}
+
+export default Unsubscribe;


### PR DESCRIPTION
- Add GET /api/v1/marketing/unsubscribe?email= public endpoint (no auth)
- Add publicUnsubscribe controller — GDPR safe, no email enumeration
- Add Unsubscribe.jsx page — loading/success/error states, matches site style
- Wire unsubscribe route into Frontend App.jsx at /unsubscribe
- Fix drip email unsubscribe links to use encodeURIComponent(recipient.email)