### PR TITLE
feat: robots.txt and sitemap.xml on ellcworth.com

### DIFF
--- a/Frontend/public/robots.txt
+++ b/Frontend/public/robots.txt
@@ -1,4 +1,3 @@
 User-agent: *
 Allow: /
-
 Sitemap: https://www.ellcworth.com/sitemap.xml

--- a/Frontend/vercel.json
+++ b/Frontend/vercel.json
@@ -1,3 +1,12 @@
 {
-  "rewrites": [{ "source": "/(.*)", "destination": "/" }]
+  "rewrites": [
+    {
+      "source": "/sitemap.xml",
+      "destination": "https://elx-project.onrender.com/sitemap.xml"
+    },
+    {
+      "source": "/(.*)",
+      "destination": "/"
+    }
+  ]
 }


### PR DESCRIPTION
- robots.txt served as static file from Frontend/public/
- sitemap.xml proxied via Vercel rewrite to Render backend (stays dynamic)
- Both accessible at www.ellcworth.com/robots.txt and /sitemap.xml