### PR TITLE
fix: RequireCustomerAuth SSR hydration error

### DIFF
--- a/frontend-next/app/components/RequireCustomerAuth.tsx
+++ b/frontend-next/app/components/RequireCustomerAuth.tsx
@@ -1,10 +1,8 @@
 "use client";
-
 import { useEffect, useMemo, useState } from "react";
 import { useRouter, usePathname } from "next/navigation";
 import {
   readCustomerSession,
-  clearCustomerAuth,
   ALLOWED_CUSTOMER_ROLES,
 } from "../lib/customerAuth";
 
@@ -15,25 +13,23 @@ export default function RequireCustomerAuth({
 }) {
   const router = useRouter();
   const pathname = usePathname();
+  const [auth, setAuth] = useState<ReturnType<typeof readCustomerSession> | null>(null);
+  const [checked, setChecked] = useState(false);
 
-  const [auth, setAuth] = useState(() => readCustomerSession());
+  useEffect(() => {
+    const current = readCustomerSession();
+    setAuth(current);
+    setChecked(true);
+    if (!current.token || !current.user) {
+      router.replace(`/login?from=${encodeURIComponent(pathname)}`);
+    }
+  }, [router, pathname]);
 
-  // Keep auth in sync across tabs
   useEffect(() => {
     const onStorage = () => setAuth(readCustomerSession());
     window.addEventListener("storage", onStorage);
     return () => window.removeEventListener("storage", onStorage);
   }, []);
-
-  // Guard redirect on mount and route changes
-  useEffect(() => {
-    const current = readCustomerSession();
-    setAuth(current);
-
-    if (!current.token || !current.user) {
-      router.replace(`/login?from=${encodeURIComponent(pathname)}`);
-    }
-  }, [router, pathname]);
 
   const isAllowed = useMemo(
     () =>
@@ -42,6 +38,7 @@ export default function RequireCustomerAuth({
     [auth]
   );
 
+  if (!checked) return null;
   if (!isAllowed) return null;
   return <>{children}</>;
 }


### PR DESCRIPTION
useState initializer was calling readCustomerSession() on the server where localStorage doesn't exist, causing React hydration mismatch errors #419 and #321. Fix: initialise auth state to null, read session only in useEffect after mount.