### PR TITLE
fix: auth token persistence — always use localStorage

### DIFF
--- a/frontend-next/app/lib/customerAuth.ts
+++ b/frontend-next/app/lib/customerAuth.ts
@@ -107,17 +107,11 @@ export function writeCustomerSession({
 
   localStorage.setItem(CUSTOMER_SESSION_KEY, JSON.stringify(session));
 
-  if (remember) {
-    localStorage.setItem(CUSTOMER_TOKEN_KEY, token);
-    localStorage.setItem(CUSTOMER_USER_KEY, JSON.stringify(user));
-    sessionStorage.removeItem(CUSTOMER_TOKEN_KEY);
-    sessionStorage.removeItem(CUSTOMER_USER_KEY);
-  } else {
-    sessionStorage.setItem(CUSTOMER_TOKEN_KEY, token);
-    sessionStorage.setItem(CUSTOMER_USER_KEY, JSON.stringify(user));
-    localStorage.removeItem(CUSTOMER_TOKEN_KEY);
-    localStorage.removeItem(CUSTOMER_USER_KEY);
-  }
+  // Always use localStorage so token survives page reloads
+  localStorage.setItem(CUSTOMER_TOKEN_KEY, token);
+  localStorage.setItem(CUSTOMER_USER_KEY, JSON.stringify(user));
+  sessionStorage.removeItem(CUSTOMER_TOKEN_KEY);
+  sessionStorage.removeItem(CUSTOMER_USER_KEY);
 }
 
 export function readCustomerToken(): string | null {

--- a/frontend-next/app/shipmentdetails/[id]/page.tsx
+++ b/frontend-next/app/shipmentdetails/[id]/page.tsx
@@ -1,5 +1,6 @@
 export const dynamic = "force-dynamic";
 import type { Metadata } from "next";
+import { Suspense } from "react";
 import ShipmentDetailsClient from "../../components/ShipmentDetailsClient";
 
 export const metadata: Metadata = {
@@ -11,5 +12,9 @@ type Props = { params: Promise<{ id: string }> };
 
 export default async function ShipmentDetailsPage({ params }: Props) {
   const { id } = await params;
-  return <ShipmentDetailsClient id={id} />;
+  return (
+    <Suspense fallback={<div className="bg-[#1A2930] min-h-screen" />}>
+      <ShipmentDetailsClient id={id} />
+    </Suspense>
+  );
 }


### PR DESCRIPTION
sessionStorage is wiped on full page reloads. Token and user now always written to localStorage so the session survives navigating to shipmentdetails and other pages.