### PR TITLE
fix: dashboard pending count includes request_received

### DIFF
--- a/Admin/src/pages/Charts.jsx
+++ b/Admin/src/pages/Charts.jsx
@@ -47,6 +47,7 @@ const Panel = ({ title, subtitle, children }) => (
 const titleCaseStatus = (s) => {
   const map = {
     pending: "Pending",
+    request_received: "Pending",
     booked: "Booked",
     at_origin_yard: "At origin yard",
     loaded: "Loaded",


### PR DESCRIPTION
Backend was counting pending as 0 because new shipments have status 'request_received' not 'pending'. Backend now merges request_received into pending in byStatus. Admin Charts.jsx also updated to label request_received as Pending.