### PR TITLE
fix: dashboard byStatus — merge request_received into pending

### DIFF
--- a/Backend/controllers/shipment.js
+++ b/Backend/controllers/shipment.js
@@ -1811,7 +1811,8 @@ async function getDashboardStats(req, res) {
 
     const delivered = byStatus.delivered || 0;
     const cancelled = byStatus.cancelled || 0;
-    const pending = byStatus.pending || 0;
+    const pending = (byStatus.pending || 0) + (byStatus.request_received || 0);
+    if (byStatus.request_received) { byStatus.pending = pending; delete byStatus.request_received; }
 
     const active =
       totalShipments - delivered - cancelled - pending >= 0


### PR DESCRIPTION
The sed replacement in the previous PR failed silently. Applied fix directly: request_received count now merged into pending in both byStatus and totals.