### PR TITLE
fix: LCL navbar service link

### DIFF
--- a/frontend-next/app/components/Navbar.tsx
+++ b/frontend-next/app/components/Navbar.tsx
@@ -16,7 +16,7 @@ const SERVICES_LINKS = [
     group: "Sea Freight",
     items: [
       { label: "FCL Container (20ft / 40ft)", to: "/services/container" },
-      { label: "LCL Consolidation",           to: "/services/lcl" },
+      { label: "LCL Consolidation",           to: "/services/container" },
     ],
   },
   {


### PR DESCRIPTION
LCL Consolidation was linking to /services/lcl which doesn't exist. Points to /services/container (FCL & LCL combined page).