### PR TITLE
fix: mobile header padding

### DIFF
--- a/frontend-next/app/layout.tsx
+++ b/frontend-next/app/layout.tsx
@@ -36,7 +36,7 @@ export default function RootLayout({
       >
         <Navbar />
         {/* pt-[124px] = top bar 72px + nav bar 52px */}
-        <main className="pt-[124px]">{children}</main>
+        <main className="pt-[72px] md:pt-[124px]">{children}</main>
         <Footer />
 
         {/* WhatsApp floating button */}


### PR DESCRIPTION
Dark navbar is ~72px on mobile, amber bar hidden. pt-[124px] was leaving a white gap. Now pt-[72px] md:pt-[124px].