### PR TITLE
fix: mobile header padding 65px

### DIFF
--- a/frontend-next/app/layout.tsx
+++ b/frontend-next/app/layout.tsx
@@ -36,7 +36,7 @@ export default function RootLayout({
       >
         <Navbar />
         {/* pt-[124px] = top bar 72px + nav bar 52px */}
-        <main className="pt-[72px] md:pt-[124px]">{children}</main>
+        <main className="pt-[65px] md:pt-[124px]">{children}</main>
         <Footer />
 
         {/* WhatsApp floating button */}


### PR DESCRIPTION
Header renders at 65px on mobile. pt-[65px] md:pt-[124px].