### PR TITLE
feat: agreed rate for registered customers

### DIFF
--- a/Admin/src/pages/UserDetails.jsx
+++ b/Admin/src/pages/UserDetails.jsx
@@ -35,6 +35,11 @@ const getStatusLabel = (status) => {
 const displayDate = (iso) =>
   iso ? new Date(iso).toISOString().slice(0, 10) : "—";
 
+const isRateActive = (rate) => {
+  if (!rate?.amount || !rate?.validUntil) return false;
+  return new Date(rate.validUntil) > new Date();
+};
+
 const FieldRow = ({ label, value, mono = false }) => (
   <div className="flex items-start justify-between gap-4 py-1">
     <span className="text-gray-500 text-xs">{label}</span>
@@ -70,6 +75,10 @@ const UserDetails = () => {
   const [user, setUser] = useState(null);
   const [loadError, setLoadError] = useState("");
   const [loading, setLoading] = useState(false);
+  const [rateForm, setRateForm] = useState({ amount: "", currency: "GBP", description: "", validUntil: "" });
+  const [rateSaving, setRateSaving] = useState(false);
+  const [rateMsg, setRateMsg] = useState("");
+  const [rateEdit, setRateEdit] = useState(false);
 
   const statusLabel = useMemo(
     () => getStatusLabel(user?.status),
@@ -281,6 +290,173 @@ const UserDetails = () => {
                   <div className="text-sm text-gray-800 whitespace-pre-line">
                     {user.notes || "No notes recorded for this customer."}
                   </div>
+                </SectionCard>
+              </div>
+
+              {/* Agreed Rate */}
+              <div className="md:col-span-2">
+                <SectionCard
+                  title="Agreed Rate"
+                  subtitle="Set a pre-agreed rate for this customer. Visible to them on new booking until expiry."
+                >
+                  {!rateEdit ? (
+                    <div>
+                      {user.agreedRate?.amount && isRateActive(user.agreedRate) ? (
+                        <div className="space-y-2 mb-4">
+                          <div className="flex items-center gap-2">
+                            <span className="inline-flex items-center px-2.5 py-1 rounded-full text-xs font-semibold bg-emerald-100 text-emerald-700 border border-emerald-300">
+                              Active
+                            </span>
+                            <span className="text-sm font-semibold text-gray-900">
+                              {user.agreedRate.currency || "GBP"} {Number(user.agreedRate.amount).toLocaleString()}
+                            </span>
+                          </div>
+                          {user.agreedRate.description && (
+                            <p className="text-sm text-gray-600">{user.agreedRate.description}</p>
+                          )}
+                          <p className="text-xs text-gray-400">
+                            Valid until: <span className="font-semibold text-gray-600">{displayDate(user.agreedRate.validUntil)}</span>
+                            {user.agreedRate.setBy && ` · Set by ${user.agreedRate.setBy}`}
+                          </p>
+                        </div>
+                      ) : user.agreedRate?.amount ? (
+                        <div className="mb-4">
+                          <span className="inline-flex items-center px-2.5 py-1 rounded-full text-xs font-semibold bg-red-100 text-red-600 border border-red-200">
+                            Expired — {displayDate(user.agreedRate.validUntil)}
+                          </span>
+                        </div>
+                      ) : (
+                        <p className="text-sm text-gray-400 mb-4">No agreed rate set for this customer.</p>
+                      )}
+                      <div className="flex gap-2">
+                        <button
+                          onClick={() => {
+                            setRateForm({
+                              amount: user.agreedRate?.amount || "",
+                              currency: user.agreedRate?.currency || "GBP",
+                              description: user.agreedRate?.description || "",
+                              validUntil: user.agreedRate?.validUntil ? user.agreedRate.validUntil.slice(0,10) : "",
+                            });
+                            setRateEdit(true);
+                            setRateMsg("");
+                          }}
+                          className="px-4 py-1.5 rounded-lg text-xs font-semibold bg-[#1A2930] text-white hover:bg-[#FFA500] hover:text-black transition"
+                        >
+                          {user.agreedRate?.amount ? "Edit rate" : "Set rate"}
+                        </button>
+                        {user.agreedRate?.amount && (
+                          <button
+                            disabled={rateSaving}
+                            onClick={async () => {
+                              if (!window.confirm("Clear the agreed rate for this customer?")) return;
+                              setRateSaving(true); setRateMsg("");
+                              try {
+                                const token = localStorage.getItem("token");
+                                const res = await fetch(`${USERS_API}/${userId}/agreed-rate`, {
+                                  method: "PATCH",
+                                  headers: { "Content-Type": "application/json", ...(token ? { Authorization: `Bearer ${token}` } : {}) },
+                                  body: JSON.stringify({ clear: true }),
+                                });
+                                const data = await res.json();
+                                if (!res.ok) throw new Error(data?.message || "Failed");
+                                setUser(data.user);
+                                setRateMsg("Rate cleared.");
+                              } catch (err) {
+                                setRateMsg(err.message);
+                              } finally {
+                                setRateSaving(false);
+                              }
+                            }}
+                            className="px-4 py-1.5 rounded-lg text-xs font-semibold border border-red-300 text-red-500 hover:bg-red-50 transition disabled:opacity-40"
+                          >
+                            Clear rate
+                          </button>
+                        )}
+                      </div>
+                      {rateMsg && <p className="text-xs mt-2 text-emerald-600">{rateMsg}</p>}
+                    </div>
+                  ) : (
+                    <div className="space-y-3">
+                      <div className="grid grid-cols-2 gap-3">
+                        <div>
+                          <label className="block text-xs text-gray-500 mb-1">Amount</label>
+                          <input
+                            type="number"
+                            value={rateForm.amount}
+                            onChange={(e) => setRateForm((p) => ({ ...p, amount: e.target.value }))}
+                            placeholder="e.g. 750"
+                            className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm outline-none focus:border-[#FFA500]"
+                          />
+                        </div>
+                        <div>
+                          <label className="block text-xs text-gray-500 mb-1">Currency</label>
+                          <select
+                            value={rateForm.currency}
+                            onChange={(e) => setRateForm((p) => ({ ...p, currency: e.target.value }))}
+                            className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm outline-none focus:border-[#FFA500]"
+                          >
+                            <option value="GBP">GBP</option>
+                            <option value="USD">USD</option>
+                            <option value="EUR">EUR</option>
+                            <option value="GHS">GHS</option>
+                          </select>
+                        </div>
+                      </div>
+                      <div>
+                        <label className="block text-xs text-gray-500 mb-1">Description</label>
+                        <input
+                          value={rateForm.description}
+                          onChange={(e) => setRateForm((p) => ({ ...p, description: e.target.value }))}
+                          placeholder="e.g. RoRo to Tema — per unit"
+                          className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm outline-none focus:border-[#FFA500]"
+                        />
+                      </div>
+                      <div>
+                        <label className="block text-xs text-gray-500 mb-1">Valid until</label>
+                        <input
+                          type="date"
+                          value={rateForm.validUntil}
+                          onChange={(e) => setRateForm((p) => ({ ...p, validUntil: e.target.value }))}
+                          className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm outline-none focus:border-[#FFA500]"
+                        />
+                      </div>
+                      {rateMsg && <p className="text-xs text-red-500">{rateMsg}</p>}
+                      <div className="flex gap-2 pt-1">
+                        <button
+                          disabled={rateSaving || !rateForm.amount || !rateForm.validUntil}
+                          onClick={async () => {
+                            setRateSaving(true); setRateMsg("");
+                            try {
+                              const token = localStorage.getItem("token");
+                              const res = await fetch(`${USERS_API}/${userId}/agreed-rate`, {
+                                method: "PATCH",
+                                headers: { "Content-Type": "application/json", ...(token ? { Authorization: `Bearer ${token}` } : {}) },
+                                body: JSON.stringify({ ...rateForm, setBy: "Admin" }),
+                              });
+                              const data = await res.json();
+                              if (!res.ok) throw new Error(data?.message || "Failed");
+                              setUser(data.user);
+                              setRateEdit(false);
+                              setRateMsg("Rate saved.");
+                            } catch (err) {
+                              setRateMsg(err.message);
+                            } finally {
+                              setRateSaving(false);
+                            }
+                          }}
+                          className="px-5 py-2 rounded-full bg-[#1A2930] text-white text-xs font-semibold hover:bg-[#FFA500] hover:text-black transition disabled:opacity-40"
+                        >
+                          {rateSaving ? "Saving…" : "Save rate"}
+                        </button>
+                        <button
+                          onClick={() => { setRateEdit(false); setRateMsg(""); }}
+                          className="px-5 py-2 rounded-full border border-gray-300 text-gray-500 text-xs font-semibold hover:bg-gray-50 transition"
+                        >
+                          Cancel
+                        </button>
+                      </div>
+                    </div>
+                  )}
                 </SectionCard>
               </div>
             </div>

--- a/Backend/models/User.js
+++ b/Backend/models/User.js
@@ -88,6 +88,16 @@ const UserSchema = new mongoose.Schema(
     // Soft delete + onboarding
     isDeleted: { type: Boolean, default: false, index: true },
     welcomeMailSent: { type: Boolean, default: false },
+
+    // Agreed rate — set by admin, visible to customer on new booking
+    agreedRate: {
+      amount:      { type: Number, default: null },
+      currency:    { type: String, default: "GBP" },
+      description: { type: String, default: "" },
+      validUntil:  { type: Date, default: null },
+      setBy:       { type: String, default: "" },
+      setAt:       { type: Date, default: null },
+    },
   },
   { timestamps: true }
 );

--- a/Backend/routes/user.js
+++ b/Backend/routes/user.js
@@ -17,4 +17,23 @@ router.get("/:id", requireAuth, requireAdmin, getUserById);
 router.put("/:id", requireAuth, requireAdmin, updateUser);
 router.delete("/:id", requireAuth, requireAdmin, deleteUser);
 
+// Agreed rate — admin sets/clears on a customer account
+router.patch("/:id/agreed-rate", requireAuth, requireAdmin, async (req, res) => {
+  try {
+    const { amount, currency, description, validUntil, setBy, clear } = req.body;
+    const User = require("../models/User");
+
+    const update = clear
+      ? { agreedRate: { amount: null, currency: "GBP", description: "", validUntil: null, setBy: "", setAt: null } }
+      : { agreedRate: { amount, currency: currency || "GBP", description: description || "", validUntil: validUntil || null, setBy: setBy || "Admin", setAt: new Date() } };
+
+    const user = await User.findByIdAndUpdate(req.params.id, { $set: update }, { new: true, select: "-password" });
+    if (!user) return res.status(404).json({ message: "User not found." });
+    return res.status(200).json({ message: clear ? "Agreed rate cleared." : "Agreed rate saved.", user });
+  } catch (err) {
+    console.error("agreed-rate patch error:", err);
+    return res.status(500).json({ message: "Server error.", error: err.message });
+  }
+});
+
 module.exports = router;

--- a/frontend-next/app/components/NewBookingClient.tsx
+++ b/frontend-next/app/components/NewBookingClient.tsx
@@ -39,6 +39,28 @@ function NewBookingInner() {
     loading: false, error: "", success: "", fieldErrors: [] as FieldError[],
   });
 
+  const [agreedRate, setAgreedRate] = useState<{
+    amount: number; currency: string; description: string; validUntil: string;
+  } | null>(null);
+  const [useAgreedRate, setUseAgreedRate] = useState(false);
+
+  useEffect(() => {
+    const token = readCustomerToken();
+    if (!token) return;
+    fetch(`${API_BASE_URL}/api/v1/auth/me`, {
+      headers: { Authorization: `Bearer ${token}` },
+    })
+      .then((r) => r.json())
+      .then((data) => {
+        const rate = data?.data?.agreedRate;
+        if (rate?.amount && rate?.validUntil && new Date(rate.validUntil) > new Date()) {
+          setAgreedRate(rate);
+          setUseAgreedRate(true);
+        }
+      })
+      .catch(() => {});
+  }, []);
+
   const canSubmit = useMemo(() => {
     const emailOk = /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(String(form.shipperEmail || "").trim());
     return Boolean(
@@ -73,6 +95,11 @@ function NewBookingInner() {
         shipper: { name: form.shipperName.trim(), address: form.shipperAddress.trim(), email: form.shipperEmail.trim().toLowerCase() },
         consignee: { name: form.consigneeName.trim(), address: form.consigneeAddress.trim() },
         ports: { originPort: form.originPort.trim(), destinationPort: form.destinationPort.trim() },
+        ...(useAgreedRate && agreedRate ? {
+          meta: { useAgreedRate: true, agreedRateAmount: agreedRate.amount, agreedRateCurrency: agreedRate.currency },
+        } : {
+          meta: { quoteRequested: true },
+        }),
       };
 
       const resp = await fetch(`${API_V1}/shipments`, {
@@ -209,6 +236,40 @@ function NewBookingInner() {
                 </div>
               </div>
 
+              {/* Agreed rate banner */}
+              {agreedRate && (
+                <div className="rounded-xl border border-emerald-500/30 bg-emerald-50 px-4 py-3">
+                  <div className="flex items-start justify-between gap-3">
+                    <div>
+                      <p className="text-xs font-semibold text-emerald-700 mb-0.5">Agreed rate on file</p>
+                      <p className="text-sm font-bold text-[#1A2930]">
+                        {agreedRate.currency} {Number(agreedRate.amount).toLocaleString()}
+                        {agreedRate.description ? ` — ${agreedRate.description}` : ""}
+                      </p>
+                      <p className="text-xs text-slate-500 mt-0.5">
+                        Valid until {new Date(agreedRate.validUntil).toLocaleDateString("en-GB", { day: "numeric", month: "short", year: "numeric" })}
+                      </p>
+                    </div>
+                    <button
+                      type="button"
+                      onClick={() => setUseAgreedRate((p) => !p)}
+                      className={`flex-shrink-0 px-3 py-1.5 rounded-full text-xs font-semibold border transition ${
+                        useAgreedRate
+                          ? "bg-emerald-600 text-white border-emerald-600"
+                          : "bg-white text-slate-500 border-slate-300 hover:border-emerald-400"
+                      }`}
+                    >
+                      {useAgreedRate ? "✓ Using agreed rate" : "Use agreed rate"}
+                    </button>
+                  </div>
+                </div>
+              )}
+              {!agreedRate && (
+                <div className="rounded-xl border border-amber-200 bg-amber-50 px-4 py-3">
+                  <p className="text-xs font-semibold text-amber-700 mb-0.5">No agreed rate on file</p>
+                  <p className="text-xs text-slate-500">This booking will be submitted as a quote request. Operations will respond with a rate within 24 hours.</p>
+                </div>
+              )}
               <div className="flex items-center justify-between gap-3 pt-1">
                 <p className="text-[11px] text-slate-500">After creation, you'll see the shipment reference and milestones on the details page.</p>
                 <button type="submit" disabled={!canSubmit || status.loading}


### PR DESCRIPTION
- User model: agreedRate subdocument (amount, currency, description, validUntil, setBy, setAt)
- Route: PATCH /api/v1/users/:id/agreed-rate (admin only) — set or clear
- Admin UserDetails: Agreed Rate card with set/edit/clear UI, active/expired status
- NewBookingClient: fetches /auth/me on mount, shows agreed rate banner if active, toggle to use it or request quote, payload includes meta.useAgreedRate or meta.quoteRequested