### PR TITLE
fix: restoreUser missing from user routes import

### DIFF
--- a/Backend/routes/user.js
+++ b/Backend/routes/user.js
@@ -5,6 +5,7 @@ const {
   getAllUsers,
   getUserById,
   updateUser,
+  restoreUser,
 } = require("../controllers/user");
 const { requireAuth, requireAdmin } = require("../middleware/auth");
 


### PR DESCRIPTION
restoreUser was exported from controller but not imported in routes — caused Render startup crash.