### PR TITLE
fix: admin users API path

### DIFF
--- a/Admin/src/pages/UserDetails.jsx
+++ b/Admin/src/pages/UserDetails.jsx
@@ -3,7 +3,7 @@ import { useEffect, useMemo, useState } from "react";
 import { useParams, useNavigate, useLocation, Link } from "react-router-dom";
 
 const API_BASE = import.meta.env.VITE_API_BASE_URL || "http://localhost:8000";
-const USERS_API = `${API_BASE}/users`;
+const USERS_API = `${API_BASE}/api/v1/users`;
 
 const normalizeStatus = (status) => {
   const s = String(status || "pending")

--- a/Admin/src/pages/Users.jsx
+++ b/Admin/src/pages/Users.jsx
@@ -5,7 +5,7 @@ import { FaTrash, FaEye, FaEdit } from "react-icons/fa";
 import { Link, useNavigate, useLocation } from "react-router-dom";
 
 const API_BASE = import.meta.env.VITE_API_BASE_URL || "http://localhost:8000";
-const USERS_API = `${API_BASE}/users`;
+const USERS_API = `${API_BASE}/api/v1/users`;
 
 // Normalize status (backend tends to be "pending/active/suspended")
 const normalizeStatus = (status) => {


### PR DESCRIPTION
UserDetails and Users pages were hitting legacy /users route. Updated to /api/v1/users so query params like ?force=true&hard=true are handled correctly.