### PR TITLE
fix: hard delete URL construction

### DIFF
--- a/Admin/src/pages/UserDetails.jsx
+++ b/Admin/src/pages/UserDetails.jsx
@@ -492,7 +492,8 @@ const UserDetails = () => {
                     onClick={async () => {
                       if (!window.confirm("Permanently delete this customer? This cannot be undone.")) return;
                       const token = localStorage.getItem("token");
-                      const res = await fetch(`${USERS_API}/${userId}?force=true&hard=true`, {
+                      const deleteUrl = USERS_API + "/" + userId + "?force=true&hard=true";
+                      const res = await fetch(deleteUrl, {
                         method: "DELETE",
                         headers: { "Content-Type": "application/json", Authorization: `Bearer ${token}` },
                       });


### PR DESCRIPTION
Template literal with & in JSX may be HTML-encoded. Building URL as string concatenation instead.