### PR TITLE
fix: fallbackRows useMemo dep array

### DIFF
--- a/Admin/src/pages/Users.jsx
+++ b/Admin/src/pages/Users.jsx
@@ -89,7 +89,7 @@ const Users = () => {
         registered: "2023-12-18",
       },
     ],
-    [showArchived, handleDelete, handleEdit, handleView]
+    []
   );
 
   const fetchUsers = async () => {


### PR DESCRIPTION
Accidental patch put handleDelete/handleEdit/handleView into fallbackRows deps — caused 'cannot access before initialization' crash. Restored to [].