### PR TITLE
feat: admin global search

### DIFF
--- a/Admin/src/components/Navbar.jsx
+++ b/Admin/src/components/Navbar.jsx
@@ -1,15 +1,159 @@
 import { Link, NavLink, useNavigate } from "react-router-dom";
+import { useState, useEffect, useRef, useCallback } from "react";
+
+const API_BASE = import.meta.env.VITE_API_BASE_URL || "http://localhost:8000";
+
+function useDebounce(value, delay) {
+  const [debounced, setDebounced] = useState(value);
+  useEffect(() => {
+    const t = setTimeout(() => setDebounced(value), delay);
+    return () => clearTimeout(t);
+  }, [value, delay]);
+  return debounced;
+}
+
+function GlobalSearch() {
+  const [query, setQuery] = useState("");
+  const [results, setResults] = useState(null);
+  const [loading, setLoading] = useState(false);
+  const [open, setOpen] = useState(false);
+  const debouncedQuery = useDebounce(query, 300);
+  const containerRef = useRef(null);
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    if (!debouncedQuery || debouncedQuery.length < 2) {
+      setResults(null);
+      setOpen(false);
+      return;
+    }
+    setLoading(true);
+    const token = localStorage.getItem("token");
+    fetch(`${API_BASE}/api/v1/search?q=${encodeURIComponent(debouncedQuery)}`, {
+      headers: { Authorization: `Bearer ${token}` },
+    })
+      .then((r) => r.json())
+      .then((data) => {
+        setResults(data);
+        setOpen(true);
+      })
+      .catch(() => setResults(null))
+      .finally(() => setLoading(false));
+  }, [debouncedQuery]);
+
+  // Close on outside click
+  useEffect(() => {
+    function handleClick(e) {
+      if (containerRef.current && !containerRef.current.contains(e.target)) {
+        setOpen(false);
+      }
+    }
+    document.addEventListener("mousedown", handleClick);
+    return () => document.removeEventListener("mousedown", handleClick);
+  }, []);
+
+  const handleSelect = (path) => {
+    setQuery("");
+    setResults(null);
+    setOpen(false);
+    navigate(path);
+  };
+
+  const hasResults = results && (results.shipments?.length > 0 || results.users?.length > 0);
+  const isEmpty = results && !hasResults;
+
+  return (
+    <div ref={containerRef} className="relative hidden md:block">
+      <div className="relative">
+        <svg className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400 w-3.5 h-3.5 pointer-events-none" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 21l-4.35-4.35M17 11A6 6 0 1 1 5 11a6 6 0 0 1 12 0z" />
+        </svg>
+        <input
+          type="text"
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          onFocus={() => hasResults && setOpen(true)}
+          placeholder="Search shipments, customers…"
+          className="bg-white/8 border border-white/10 rounded-full pl-8 pr-4 py-1.5 text-xs text-white placeholder:text-gray-500 focus:outline-none focus:border-[#FFA500]/50 w-56 transition"
+        />
+        {loading && (
+          <div className="absolute right-3 top-1/2 -translate-y-1/2 w-3 h-3 border border-[#FFA500] border-t-transparent rounded-full animate-spin" />
+        )}
+      </div>
+
+      {open && (
+        <div className="absolute top-full mt-2 right-0 w-80 bg-[#111C24] border border-white/10 rounded-xl shadow-xl overflow-hidden z-50">
+          {isEmpty && (
+            <p className="px-4 py-3 text-xs text-gray-500">No results for &ldquo;{query}&rdquo;</p>
+          )}
+
+          {results?.shipments?.length > 0 && (
+            <div>
+              <p className="px-4 pt-3 pb-1 text-[10px] font-bold tracking-[0.2em] uppercase text-[#FFA500]">
+                Shipments
+              </p>
+              {results.shipments.map((s) => (
+                <button
+                  key={s._id}
+                  onClick={() => handleSelect(`/shipments/${s._id}`)}
+                  className="w-full text-left px-4 py-2.5 hover:bg-white/5 transition flex items-center justify-between gap-3 group"
+                >
+                  <div>
+                    <p className="text-white text-xs font-semibold group-hover:text-[#FFA500] transition">
+                      {s.referenceNo}
+                    </p>
+                    <p className="text-gray-400 text-[11px]">{s.shipper?.name}</p>
+                  </div>
+                  <span className="text-[10px] text-gray-500 capitalize shrink-0">
+                    {s.status?.replace(/_/g, " ")}
+                  </span>
+                </button>
+              ))}
+            </div>
+          )}
+
+          {results?.users?.length > 0 && (
+            <div className={results?.shipments?.length > 0 ? "border-t border-white/8" : ""}>
+              <p className="px-4 pt-3 pb-1 text-[10px] font-bold tracking-[0.2em] uppercase text-[#FFA500]">
+                Customers
+              </p>
+              {results.users.map((u) => (
+                <button
+                  key={u._id}
+                  onClick={() => handleSelect(`/users/${u._id}`)}
+                  className="w-full text-left px-4 py-2.5 hover:bg-white/5 transition flex items-center justify-between gap-3 group"
+                >
+                  <div>
+                    <p className="text-white text-xs font-semibold group-hover:text-[#FFA500] transition">
+                      {u.fullname || u.company || u.email}
+                    </p>
+                    <p className="text-gray-400 text-[11px]">{u.email}</p>
+                  </div>
+                  <span className="text-[10px] text-gray-500 capitalize shrink-0">
+                    {u.status}
+                  </span>
+                </button>
+              ))}
+            </div>
+          )}
+
+          {hasResults && (
+            <div className="border-t border-white/8 px-4 py-2">
+              <p className="text-[10px] text-gray-600">Press Enter or click a result to navigate</p>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
 
 function Navbar({ onMenuClick }) {
   const navigate = useNavigate();
 
   const handleLogout = () => {
-    // ✅ Standardised auth key is "token"
     localStorage.removeItem("token");
-
-    // ✅ Optional cleanup for any legacy key you used before
     localStorage.removeItem("ellcworth_token");
-
     navigate("/login");
   };
 
@@ -22,7 +166,6 @@ function Navbar({ onMenuClick }) {
       <nav className="mx-auto flex h-[80px] max-w-7xl items-center justify-between px-4 sm:px-8 font-montserrat">
         {/* Left: Burger + Logo + Brand */}
         <div className="flex items-center gap-3">
-          {/* Mobile burger */}
           <button
             type="button"
             onClick={onMenuClick}
@@ -37,20 +180,8 @@ function Navbar({ onMenuClick }) {
             aria-label="Open menu"
             aria-controls="mobile-drawer"
           >
-            <svg
-              width="20"
-              height="20"
-              viewBox="0 0 24 24"
-              fill="none"
-              className="text-white"
-              aria-hidden="true"
-            >
-              <path
-                d="M4 6h16M4 12h16M4 18h16"
-                stroke="currentColor"
-                strokeWidth="2"
-                strokeLinecap="round"
-              />
+            <svg width="20" height="20" viewBox="0 0 24 24" fill="none" className="text-white" aria-hidden="true">
+              <path d="M4 6h16M4 12h16M4 18h16" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
             </svg>
           </button>
 
@@ -61,61 +192,27 @@ function Navbar({ onMenuClick }) {
               className="h-10 w-auto sm:h-11 transition-transform duration-150 group-hover:scale-[1.03]"
             />
             <div className="flex flex-col leading-tight">
-              <span className="text-[11px] tracking-[0.28em] uppercase text-gray-300">
-                Ellcworth
-              </span>
+              <span className="text-[11px] tracking-[0.28em] uppercase text-gray-300">Ellcworth</span>
               <span className="text-sm sm:text-base font-semibold tracking-[0.16em] text-white">
                 EXPRESS <span className="text-[#FFA500]">ADMIN</span>
               </span>
-              <span className="hidden text-[10px] text-gray-400 sm:block">
-                UK–Africa shipping portal
-              </span>
+              <span className="hidden text-[10px] text-gray-400 sm:block">UK–Africa shipping portal</span>
             </div>
           </Link>
         </div>
 
-        {/* Right: Nav links + Logout */}
+        {/* Right: Nav links + Search + Logout */}
         <div className="flex items-center gap-3 sm:gap-4">
           {/* Primary nav (desktop only) */}
           <div className="hidden md:flex items-center gap-2 text-xs font-medium">
-            <NavLink
-              to="/"
-              className={({ isActive }) =>
-                `${baseLink} ${isActive ? activeLink : ""}`
-              }
-            >
-              Dashboard
-            </NavLink>
-
-            <NavLink
-              to="/shipments"
-              className={({ isActive }) =>
-                `${baseLink} ${isActive ? activeLink : ""}`
-              }
-            >
-              Shipments
-            </NavLink>
-
-            <NavLink
-              to="/newshipment"
-              className={({ isActive }) =>
-                `${baseLink} ${isActive ? activeLink : ""}`
-              }
-            >
-              New shipment
-            </NavLink>
-
-            <NavLink
-              to="/users"
-              className={({ isActive }) =>
-                `${baseLink} ${isActive ? activeLink : ""}`
-              }
-            >
-              Customers
-            </NavLink>
+            <NavLink to="/" className={({ isActive }) => `${baseLink} ${isActive ? activeLink : ""}`}>Dashboard</NavLink>
+            <NavLink to="/shipments" className={({ isActive }) => `${baseLink} ${isActive ? activeLink : ""}`}>Shipments</NavLink>
+            <NavLink to="/newshipment" className={({ isActive }) => `${baseLink} ${isActive ? activeLink : ""}`}>New shipment</NavLink>
+            <NavLink to="/users" className={({ isActive }) => `${baseLink} ${isActive ? activeLink : ""}`}>Customers</NavLink>
           </div>
 
-          {/* Logout */}
+          <GlobalSearch />
+
           <button
             type="button"
             onClick={handleLogout}

--- a/Backend/controllers/search.js
+++ b/Backend/controllers/search.js
@@ -1,0 +1,55 @@
+const mongoose = require("mongoose");
+const Shipment = require("../models/Shipment");
+const User = require("../models/User");
+
+function isAdmin(req) {
+  return req.user && (req.user.isAdmin || req.user.role === "admin");
+}
+
+async function globalSearch(req, res) {
+  if (!isAdmin(req)) return res.status(403).json({ message: "Forbidden" });
+
+  const q = String(req.query.q || "").trim();
+  if (!q || q.length < 2) return res.json({ shipments: [], users: [] });
+
+  const regex = new RegExp(q, "i");
+
+  try {
+    const [shipments, users] = await Promise.all([
+      Shipment.find({
+        isDeleted: false,
+        $or: [
+          { referenceNo: regex },
+          { "shipper.name": regex },
+          { "consignee.name": regex },
+          { "shipper.email": regex },
+          { status: regex },
+        ],
+      })
+        .select("referenceNo shipper consignee status createdAt")
+        .sort({ createdAt: -1 })
+        .limit(6)
+        .lean(),
+
+      User.find({
+        isDeleted: false,
+        $or: [
+          { fullname: regex },
+          { email: regex },
+          { company: regex },
+          { phone: regex },
+        ],
+      })
+        .select("fullname email company status")
+        .limit(6)
+        .lean(),
+    ]);
+
+    return res.json({ shipments, users });
+  } catch (err) {
+    console.error("Global search error:", err);
+    return res.status(500).json({ message: "Search failed", error: err.message });
+  }
+}
+
+module.exports = { globalSearch };

--- a/Backend/index.js
+++ b/Backend/index.js
@@ -29,6 +29,7 @@ const analyticsRoute = require("./routes/analytics");
 const logsRoute = require("./routes/logs");
 const calendarRoute = require("./routes/calendar");
 const marketingRoute = require("./routes/marketing");
+const searchRoute = require("./routes/search");
 
 const app = express();
 
@@ -288,6 +289,7 @@ app.use("/api/v1/admin/analytics", analyticsRoute);
 app.use("/api/v1/admin/logs", logsRoute);
 app.use("/api/v1/admin/calendar", calendarRoute);
 app.use("/api/v1/marketing", marketingRoute);
+app.use("/api/v1/search", searchRoute);
 
 // --------------------
 // 404 (in JSON)

--- a/Backend/routes/search.js
+++ b/Backend/routes/search.js
@@ -1,0 +1,8 @@
+const express = require("express");
+const router = express.Router();
+const { globalSearch } = require("../controllers/search");
+const { requireAuth, requireAdmin } = require("../middleware/auth");
+
+router.get("/", requireAuth, requireAdmin, globalSearch);
+
+module.exports = router;


### PR DESCRIPTION
- GET /api/v1/search?q= — admin-only, searches shipments (referenceNo, shipper/consignee name, email, status) and users (name, email, company) in parallel
- 6 results max per entity, sorted by most recent
- Navbar search input — debounced 300ms, dropdown with grouped results
- Click navigates to /shipments/:id or /users/:id
- Closes on outside click
- Desktop only (hidden on mobile)