### PR TITLE
feat: prospect to customer conversion

### DIFF
--- a/Admin/src/pages/Marketing.jsx
+++ b/Admin/src/pages/Marketing.jsx
@@ -1936,6 +1936,31 @@ function ProspectDetail({ prospect: initial, onBack, onUpdate }) {
   const [nextActionDate, setNextActionDate] = useState(p.nextActionDate ? p.nextActionDate.slice(0,10) : "");
   const [nextActionNote, setNextActionNote] = useState(p.nextActionNote || "");
   const [caseStudy, setCaseStudy] = useState("");
+  const [converting, setConverting] = useState(false);
+  const [convertResult, setConvertResult] = useState(null);
+  const [convertError, setConvertError] = useState("");
+
+  const convertToCustomer = async () => {
+    if (!p.email) { setConvertError("Prospect has no email address."); return; }
+    if (!window.confirm(`Create a customer account for ${p.name} (${p.email}) and send them a setup email?`)) return;
+    setConverting(true); setConvertError(""); setConvertResult(null);
+    try {
+      const res = await fetch(`${MARKETING_API}/prospects/${p._id}/convert`, {
+        method: "POST", headers: authHeaders(),
+      });
+      const data = await res.json();
+      if (!res.ok) throw new Error(data?.message || "Failed");
+      setConvertResult(data);
+      const updated = { ...p, stage: "converted", convertedAt: new Date().toISOString() };
+      setP(updated);
+      onUpdate(updated);
+    } catch (err) {
+      setConvertError(err.message);
+    } finally {
+      setConverting(false);
+    }
+  };
+
 
   const patch = async (payload) => {
     setSaving(true);
@@ -2119,6 +2144,32 @@ function ProspectDetail({ prospect: initial, onBack, onUpdate }) {
             )}
           </div>
         </div>
+
+          {/* Convert to Customer */}
+          {p.stage !== "converted" ? (
+            <div className="bg-[#020617] border border-[#FFA500]/20 rounded-2xl p-5">
+              <p className="text-xs uppercase tracking-widest text-[#FFA500] mb-2">Convert to Customer</p>
+              <p className="text-sm text-gray-400 mb-4">
+                Creates a portal account for {p.name} and sends them a set-password email.
+              </p>
+              {convertError && <p className="text-red-400 text-xs mb-3">{convertError}</p>}
+              {convertResult ? (
+                <p className="text-green-400 text-sm font-semibold">
+                  Account created. Welcome email sent to {convertResult.email}.
+                </p>
+              ) : (
+                <button onClick={convertToCustomer} disabled={converting}
+                  className="px-6 py-2.5 rounded-full bg-[#FFA500] text-black text-xs font-bold uppercase tracking-widest hover:brightness-110 transition disabled:opacity-40">
+                  {converting ? "Converting..." : "Convert to Customer"}
+                </button>
+              )}
+            </div>
+          ) : (
+            <div className="bg-[#020617] border border-green-500/20 rounded-2xl p-5">
+              <p className="text-xs uppercase tracking-widest text-green-500 mb-1">Converted</p>
+              <p className="text-sm text-gray-400">This prospect has been converted to a customer account.</p>
+            </div>
+          )}
       </div>
     </div>
   );

--- a/Backend/controllers/auth.js
+++ b/Backend/controllers/auth.js
@@ -19,6 +19,15 @@ function signToken(user) {
   });
 }
 
+/** Short-lived token for first-time password setup (24h, purpose: setup) */
+function signSetupToken(user) {
+  const secret = jwtSecret();
+  if (!secret) throw new Error("JWT secret not configured");
+  return jwt.sign({ id: user._id, role: user.role, purpose: "setup" }, secret, {
+    expiresIn: "24h",
+  });
+}
+
 // Create a lightweight "req-like" object for logging when no auth middleware ran yet
 function makeAuthLogReq({ userId, role, ip, ua }) {
   return {
@@ -417,4 +426,5 @@ module.exports = {
   customerLoginUser,
   requestPasswordReset,
   resetPassword,
+  signSetupToken,
 };

--- a/Backend/controllers/prospect.js
+++ b/Backend/controllers/prospect.js
@@ -99,3 +99,83 @@ exports.deleteProspect = async (req, res) => {
     return res.status(500).json({ message: "Server error." });
   }
 };
+
+// POST /api/v1/marketing/prospects/:id/convert
+exports.convertProspect = async (req, res) => {
+  try {
+    const { id } = req.params;
+
+    const prospect = await Prospect.findById(id);
+    if (!prospect) return res.status(404).json({ message: "Prospect not found." });
+    if (prospect.stage === "converted") {
+      return res.status(400).json({ message: "Prospect already converted." });
+    }
+    if (!prospect.email) {
+      return res.status(400).json({ message: "Prospect has no email address — cannot create account." });
+    }
+
+    const User = require("../models/User");
+    const { signSetupToken } = require("./auth");
+    const { dispatchMail } = require("../utils/dispatchMail");
+
+    const existing = await User.findOne({ email: prospect.email.toLowerCase() });
+    if (existing) {
+      return res.status(409).json({ message: "A user account with this email already exists.", userId: existing._id });
+    }
+
+    // Create the user account — password placeholder, status pending until they set it
+    const user = await User.create({
+      fullname: prospect.name,
+      email: prospect.email.toLowerCase(),
+      company: prospect.company || "",
+      phone: prospect.phone || "",
+      role: "Shipper",
+      status: "pending",
+      password: require("crypto").randomBytes(32).toString("hex"), // unusable until reset
+      country: "United Kingdom",
+      address: prospect.address || "",
+    });
+
+    // Generate 24h setup token
+    const setupToken = signSetupToken(user);
+    const setupUrl = `${process.env.CLIENT_URL}/auth/reset-password/${setupToken}`;
+
+    // Send welcome email
+    await dispatchMail({
+      to: user.email,
+      subject: "Welcome to Ellcworth Express — Set Your Password",
+      html: `
+        <p>Dear ${user.fullname},</p>
+        <p>Your Ellcworth Express customer account has been created.</p>
+        <p>Click the link below to set your password and access your portal. This link expires in 24 hours.</p>
+        <p><a href="${setupUrl}" style="background:#FFA500;color:#1A2930;padding:10px 20px;border-radius:20px;text-decoration:none;font-weight:bold;">Set My Password</a></p>
+        <p>If you have any questions, reply to this email.</p>
+        <br/>
+        <p>Ellcworth Logistics</p>
+      `,
+      text: `Dear ${user.fullname},
+
+Your Ellcworth Express customer account has been created.
+
+Set your password here (expires in 24 hours):
+${setupUrl}
+
+Ellcworth Logistics`,
+    });
+
+    // Mark prospect as converted
+    prospect.stage = "converted";
+    prospect.convertedAt = new Date();
+    prospect.notes.push({ text: `Converted to customer account. User ID: ${user._id}`, createdAt: new Date() });
+    await prospect.save();
+
+    return res.status(201).json({
+      message: "Prospect converted. Welcome email sent.",
+      userId: user._id,
+      email: user.email,
+    });
+  } catch (err) {
+    console.error("convertProspect error:", err);
+    return res.status(500).json({ message: "Server error.", error: err.message });
+  }
+};

--- a/Backend/routes/marketing.js
+++ b/Backend/routes/marketing.js
@@ -20,6 +20,7 @@ const {
   createProspect,
   updateProspect,
   deleteProspect,
+  convertProspect,
 } = require("../controllers/prospect");
 
 const { requireAuth, requireAdmin } = require("../middleware/auth");
@@ -56,5 +57,6 @@ router.get("/prospects",      requireAuth, requireAdmin, getProspects);
 router.post("/prospects",     requireAuth, requireAdmin, createProspect);
 router.patch("/prospects/:id", requireAuth, requireAdmin, updateProspect);
 router.delete("/prospects/:id", requireAuth, requireAdmin, deleteProspect);
+router.post("/prospects/:id/convert", requireAuth, requireAdmin, convertProspect);
 
 module.exports = router;


### PR DESCRIPTION
- signSetupToken() added to auth.js — 24h JWT with purpose:setup claim
- POST /api/v1/marketing/prospects/:id/convert — creates User account, marks prospect converted, sends welcome email with set-password link
- Guards: no duplicate email, prospect must have email, not already converted
- Convert to Customer section in ProspectDetail — hidden once converted, shows success state with email confirmation