### PR TITLE
fix: prospect convert address validation

### DIFF
--- a/Backend/controllers/prospect.js
+++ b/Backend/controllers/prospect.js
@@ -134,7 +134,7 @@ exports.convertProspect = async (req, res) => {
       status: "pending",
       password: crypto.randomBytes(32).toString("hex"), // unusable until reset
       country: "United Kingdom",
-      address: prospect.address || "",
+      address: prospect.address || "To be updated",
     });
 
     // Generate 24h setup token


### PR DESCRIPTION
User model requires address. Prospects won't always have one — use 'To be updated' placeholder so the account is created. Customer can update via profile.