### PR TITLE
Fix: restore Roboto and Montserrat fonts

### DIFF
--- a/frontend-next/app/globals.css
+++ b/frontend-next/app/globals.css
@@ -5,7 +5,6 @@
   --elx-amber: #FFA500;
   --elx-dark:  #0B141A;
   --elx-slate: #9A9EAB;
-
   --background: #ffffff;
   --foreground: #171717;
 }
@@ -17,12 +16,16 @@
   --color-elx-amber:   var(--elx-amber);
   --color-elx-dark:    var(--elx-dark);
   --color-elx-slate:   var(--elx-slate);
-  --font-sans: var(--font-geist-sans);
-  --font-mono: var(--font-geist-mono);
+  --font-heading: var(--font-roboto);
+  --font-sans:    var(--font-montserrat);
 }
 
 body {
   background: var(--background);
   color: var(--foreground);
-  font-family: Arial, Helvetica, sans-serif;
+  font-family: var(--font-montserrat), Arial, sans-serif;
+}
+
+h1, h2, h3, h4, h5, h6 {
+  font-family: var(--font-roboto), Arial, sans-serif;
 }

--- a/frontend-next/app/layout.tsx
+++ b/frontend-next/app/layout.tsx
@@ -1,17 +1,19 @@
 import type { Metadata } from "next";
-import { Geist, Geist_Mono } from "next/font/google";
+import { Roboto, Montserrat } from "next/font/google";
 import "./globals.css";
 import Navbar from "./components/Navbar";
 import Footer from "./components/Footer";
 
-const geistSans = Geist({
-  variable: "--font-geist-sans",
+const roboto = Roboto({
+  variable: "--font-roboto",
   subsets: ["latin"],
+  weight: ["400", "500", "700"],
 });
 
-const geistMono = Geist_Mono({
-  variable: "--font-geist-mono",
+const montserrat = Montserrat({
+  variable: "--font-montserrat",
   subsets: ["latin"],
+  weight: ["400", "500", "600", "700"],
 });
 
 export const metadata: Metadata = {
@@ -32,15 +34,14 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased`}
+        className={`${roboto.variable} ${montserrat.variable} antialiased`}
       >
         <Navbar />
         {/* pt-[124px] = top bar 72px + nav bar 52px */}
         <main className="pt-[65px] md:pt-[124px]">{children}</main>
         <Footer />
-
         {/* WhatsApp floating button */}
-        <a
+        
           href="https://wa.me/447776234234?text=Hello%20Ellcworth%2C%20I%20have%20a%20shipping%20enquiry."
           target="_blank"
           rel="noopener noreferrer"


### PR DESCRIPTION
- Replaces Geist defaults with Roboto (headings) and Montserrat (body)
- Wired via next/font/google as CSS variables --font-roboto and --font-montserrat
- globals.css updated to apply fonts to body and h1-h6