### PR TITLE
Feat: expand institutional page — hospitals, banks, government, NGOs

### DIFF
--- a/frontend-next/app/institutional/page.tsx
+++ b/frontend-next/app/institutional/page.tsx
@@ -2,55 +2,65 @@ import type { Metadata } from "next";
 import Link from "next/link";
 
 export const metadata: Metadata = {
-  title: "Institutional & Academic Cargo UK to Ghana | Ellcworth Express",
+  title: "Institutional Cargo UK to Africa | Ellcworth Express",
   description:
-    "Ellcworth Express ships for universities, NGOs and UK exporters to Africa — sealed, documented, on time. Book a 15-minute call to discuss your institutional shipping needs.",
+    "Ellcworth Express ships for universities, hospitals, banks, government ministries and NGOs — sealed, documented, on time. Book a 15-minute call to discuss your institutional shipping needs.",
   alternates: { canonical: "https://www.ellcworth.com/institutional" },
   openGraph: {
-    title: "Institutional & Academic Cargo UK to Ghana | Ellcworth Express",
+    title: "Institutional Cargo UK to Africa | Ellcworth Express",
     description:
-      "Ellcworth Express ships for universities, NGOs and UK exporters to Africa — sealed, documented, on time. 12 years. Zero institutional deadlines missed.",
+      "Ellcworth Express ships for universities, hospitals, banks, government ministries and NGOs — sealed, documented, on time. 12 years. Zero institutional deadlines missed.",
     url: "https://www.ellcworth.com/institutional",
     type: "website",
     images: [{ url: "https://www.ellcworth.com/ellc_hero1.png" }],
   },
   twitter: {
     card: "summary_large_image",
-    title: "Institutional & Academic Cargo UK to Ghana | Ellcworth Express",
+    title: "Institutional Cargo UK to Africa | Ellcworth Express",
     description:
-      "Ellcworth Express ships for universities, NGOs and UK exporters to Africa — sealed, documented, on time. 12 years. Zero institutional deadlines missed.",
+      "Ellcworth Express ships for universities, hospitals, banks, government ministries and NGOs — sealed, documented, on time. 12 years. Zero institutional deadlines missed.",
   },
 };
 
 const cargoTypes = [
   {
     icon: "🎓",
-    title: "Blank degree certificates",
-    body: "Tamper-proof, time-critical. Collected from UK printers, sealed and delivered to campus before graduation. We have never missed a deadline in 12 years.",
+    title: "Academic & ceremonial cargo",
+    body: "Blank degree certificates, regalia and academic materials. Tamper-proof, time-critical. Collected from UK printers, sealed and delivered to campus before graduation. We have never missed a deadline in 12 years.",
+  },
+  {
+    icon: "🏥",
+    title: "Medical & healthcare procurement",
+    body: "Hospital equipment, diagnostic devices, pharmaceutical supplies and consumables for healthcare procurement agencies. Handled with the documentation discipline that institutional supply chains demand.",
+  },
+  {
+    icon: "🏦",
+    title: "Banking & financial equipment",
+    body: "ATM units, cash-handling equipment, server infrastructure and secure IT hardware for banks and financial institutions. Chain-of-custody documentation provided at every stage.",
+  },
+  {
+    icon: "🏛️",
+    title: "Government & ministry cargo",
+    body: "Ministerial procurement, civil service equipment and public sector project cargo. We work within formal procurement frameworks — proper invoices, auditable documentation, named contacts.",
   },
   {
     icon: "🔬",
     title: "Lab & scientific equipment",
-    body: "Sensitive instruments requiring export documentation, careful packaging and named customs handling at destination.",
+    body: "Sensitive instruments requiring export documentation, careful packaging and named customs handling at destination. Research institutions and teaching hospitals served.",
   },
   {
     icon: "📚",
-    title: "Library & IT equipment",
-    body: "Books, servers, terminals and AV equipment — consolidated at our network near UK ports and shipped on the next available vessel.",
+    title: "Library, IT & AV equipment",
+    body: "Books, servers, terminals and AV equipment consolidated at our network near UK ports and shipped on the next available vessel.",
   },
   {
-    icon: "🏥",
-    title: "Medical & humanitarian supplies",
-    body: "NGO and faith-based organisation shipments handled with the documentation discipline that institutional procurement requires.",
-  },
-  {
-    icon: "🏛️",
-    title: "Regalia & ceremonial items",
-    body: "High-value, low-tolerance cargo that must arrive intact and on schedule. Sealed, insured and tracked from collection to campus.",
+    icon: "🌍",
+    title: "NGO & humanitarian supplies",
+    body: "Faith-based organisations, development agencies and humanitarian NGOs. We understand donor-funded procurement requirements and provide the paper trail your auditors need.",
   },
   {
     icon: "⚙️",
-    title: "Industrial & machinery",
+    title: "Industrial & project cargo",
     body: "OOG and heavy-lift assessed on merit. If we can do it well, we will. If not, we will say so and refer you to someone who can.",
   },
 ];
@@ -91,7 +101,16 @@ const whyItems = [
 const stats = [
   { stat: "12+", label: "Years on the UK–West Africa corridor" },
   { stat: "0", label: "Institutional deadlines missed" },
-  { stat: "6+", label: "Ghanaian universities served" },
+  { stat: "10+", label: "Institutions served across education, health and government" },
+];
+
+const institutionTypes = [
+  { icon: "🎓", label: "Universities & Schools" },
+  { icon: "🏥", label: "Hospitals & Healthcare Agencies" },
+  { icon: "🏦", label: "Banks & Financial Institutions" },
+  { icon: "🏛️", label: "Government Ministries" },
+  { icon: "🌍", label: "NGOs & Development Agencies" },
+  { icon: "⛪", label: "Faith-Based Organisations" },
 ];
 
 export default function InstitutionalPage() {
@@ -110,12 +129,12 @@ export default function InstitutionalPage() {
             <span className="text-[#FFA500]">the carrier matters.</span>
           </h1>
           <p className="text-lg md:text-xl text-gray-300 max-w-2xl mb-10">
-            Ellcworth Express works with universities, NGOs and UK exporters who
-            cannot afford a shipment that goes wrong. Sealed. Documented. On
-            time.
+            Ellcworth Express works with universities, hospitals, banks,
+            government ministries and NGOs who cannot afford a shipment that
+            goes wrong. Sealed. Documented. On time.
           </p>
           <div className="flex flex-col sm:flex-row gap-4">
-            <a
+            
               href="https://calendly.com/ellcworth/15min"
               target="_blank"
               rel="noopener noreferrer"
@@ -123,8 +142,7 @@ export default function InstitutionalPage() {
             >
               Book a 15-minute call
             </a>
-
-            <a
+            
               href="mailto:cs@ellcworth.com"
               className="inline-flex items-center justify-center rounded-full border border-white/30 bg-white/5 text-white px-8 py-3 text-sm font-semibold tracking-[0.14em] uppercase hover:bg-white/10 transition"
             >
@@ -134,8 +152,37 @@ export default function InstitutionalPage() {
         </div>
       </section>
 
-      {/* Certificate proof strip */}
+      {/* Who we serve */}
       <section className="py-16 md:py-24 bg-white">
+        <div className="mx-auto max-w-4xl px-4 md:px-6 lg:px-8">
+          <span className="inline-flex items-center rounded-full bg-[#1A2930] text-[#FFA500] px-3 py-1 text-[11px] font-semibold tracking-[0.16em] uppercase mb-4">
+            Who We Serve
+          </span>
+          <h2 className="text-2xl md:text-3xl font-semibold uppercase text-[#1A2930] mb-4">
+            Any institution that needs it done right.
+          </h2>
+          <p className="text-gray-600 text-base md:text-lg leading-relaxed mb-10 max-w-2xl">
+            Our institutional clients share one thing: the cost of a logistics
+            failure is far higher than the cost of the shipment. Whether that is
+            a graduation ceremony, a hospital procurement deadline or a
+            government ministry tender, we treat every consignment accordingly.
+          </p>
+          <div className="grid grid-cols-2 sm:grid-cols-3 gap-4">
+            {institutionTypes.map((item) => (
+              <div
+                key={item.label}
+                className="rounded-2xl border border-gray-200 bg-[#F9FAFB] px-5 py-5 flex items-center gap-3"
+              >
+                <span className="text-2xl flex-shrink-0">{item.icon}</span>
+                <p className="text-sm font-semibold text-[#1A2930]">{item.label}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* Certificate proof strip */}
+      <section className="py-16 md:py-24 bg-[#EDECEC]">
         <div className="mx-auto max-w-4xl px-4 md:px-6 lg:px-8">
           <span className="inline-flex items-center rounded-full bg-[#1A2930] text-[#FFA500] px-3 py-1 text-[11px] font-semibold tracking-[0.16em] uppercase mb-4">
             Track Record
@@ -164,16 +211,17 @@ export default function InstitutionalPage() {
               In 12 years, we have never let a single institution down.
             </p>
             <p>
-              That track record is not an accident. It is the result of a
-              logistics process built around institutional requirements — not
-              adapted from a consumer model.
+              That track record extends beyond academia. The same process —
+              sealed, documented, tracked, delivered — is what hospitals,
+              procurement agencies and government ministries get when they
+              ship with us. The cargo changes. The standard does not.
             </p>
           </div>
           <div className="grid grid-cols-1 sm:grid-cols-3 gap-6">
             {stats.map((item) => (
               <div
                 key={item.label}
-                className="rounded-2xl border border-gray-200 bg-[#F9FAFB] px-6 py-6 text-center"
+                className="rounded-2xl border border-gray-200 bg-white px-6 py-6 text-center"
               >
                 <p className="text-4xl font-bold text-[#FFA500] mb-2">
                   {item.stat}
@@ -186,7 +234,7 @@ export default function InstitutionalPage() {
       </section>
 
       {/* Why Ellcworth */}
-      <section className="py-16 md:py-24 bg-[#EDECEC]">
+      <section className="py-16 md:py-24 bg-white">
         <div className="mx-auto max-w-4xl px-4 md:px-6 lg:px-8">
           <span className="inline-flex items-center rounded-full bg-[#1A2930] text-[#FFA500] px-3 py-1 text-[11px] font-semibold tracking-[0.16em] uppercase mb-4">
             How We Work
@@ -198,7 +246,7 @@ export default function InstitutionalPage() {
             {whyItems.map((item) => (
               <div
                 key={item.number}
-                className="rounded-2xl border border-gray-200 bg-white px-6 py-6 flex gap-5"
+                className="rounded-2xl border border-gray-200 bg-[#F9FAFB] px-6 py-6 flex gap-5"
               >
                 <span className="text-[#FFA500] font-bold text-sm tracking-widest flex-shrink-0 pt-1">
                   {item.number}
@@ -218,7 +266,7 @@ export default function InstitutionalPage() {
       </section>
 
       {/* Cargo types */}
-      <section className="py-16 md:py-24 bg-white">
+      <section className="py-16 md:py-24 bg-[#EDECEC]">
         <div className="mx-auto max-w-4xl px-4 md:px-6 lg:px-8">
           <span className="inline-flex items-center rounded-full bg-[#1A2930] text-[#FFA500] px-3 py-1 text-[11px] font-semibold tracking-[0.16em] uppercase mb-4">
             What We Ship
@@ -230,7 +278,7 @@ export default function InstitutionalPage() {
             {cargoTypes.map((item) => (
               <div
                 key={item.title}
-                className="rounded-2xl border border-gray-200 bg-[#F9FAFB] px-6 py-6 flex gap-4"
+                className="rounded-2xl border border-gray-200 bg-white px-6 py-6 flex gap-4"
               >
                 <span className="text-3xl flex-shrink-0">{item.icon}</span>
                 <div>
@@ -248,7 +296,7 @@ export default function InstitutionalPage() {
       </section>
 
       {/* Retainer callout */}
-      <section className="py-16 md:py-20 bg-[#EDECEC]">
+      <section className="py-16 md:py-20 bg-white">
         <div className="mx-auto max-w-4xl px-4 md:px-6 lg:px-8">
           <div className="rounded-2xl bg-[#1A2930] px-8 py-10 md:px-12 md:py-12 flex flex-col md:flex-row gap-8 items-start">
             <div className="flex-1">
@@ -259,15 +307,15 @@ export default function InstitutionalPage() {
                 Ship regularly? Lock in a monthly retainer.
               </h2>
               <p className="text-gray-300 text-sm md:text-base leading-relaxed">
-                Universities, NGOs and exporters with regular volumes can move
-                to a monthly retainer — a guaranteed fortnightly sea-freight
-                slot, priority air access, pre-negotiated rates and a named
-                account manager. No competitor on this corridor offers this. Ask
-                us about it on the call.
+                Universities, hospitals, banks and NGOs with regular volumes can
+                move to a monthly retainer — a guaranteed fortnightly
+                sea-freight slot, priority air access, pre-negotiated rates and
+                a named account manager. No competitor on this corridor offers
+                this. Ask us about it on the call.
               </p>
             </div>
             <div className="flex-shrink-0 flex items-center">
-              <a
+              
                 href="https://calendly.com/ellcworth/15min"
                 target="_blank"
                 rel="noopener noreferrer"
@@ -281,7 +329,7 @@ export default function InstitutionalPage() {
       </section>
 
       {/* Destinations */}
-      <section className="py-16 md:py-24 bg-white">
+      <section className="py-16 md:py-24 bg-[#EDECEC]">
         <div className="mx-auto max-w-4xl px-4 md:px-6 lg:px-8">
           <span className="inline-flex items-center rounded-full bg-[#1A2930] text-[#FFA500] px-3 py-1 text-[11px] font-semibold tracking-[0.16em] uppercase mb-4">
             Destinations
@@ -303,31 +351,34 @@ export default function InstitutionalPage() {
             </p>
           </div>
           <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
-            {(["Ghana", "Nigeria", "Kenya", "Other Africa"] as const).map(
-              (dest) => {
-                const href = dest === "Ghana" ? "/destinations/ghana" : null;
-                const inner = (
+            {(
+              [
+                { label: "Ghana", href: "/destinations/ghana" },
+                { label: "Nigeria", href: "/destinations/nigeria" },
+                { label: "Kenya", href: "/destinations/kenya" },
+                { label: "Other Africa", href: null },
+              ] as const
+            ).map((dest) =>
+              dest.href ? (
+                <Link
+                  key={dest.label}
+                  href={dest.href}
+                  className="group rounded-xl border border-gray-200 bg-white px-4 py-4 text-center hover:border-[#FFA500]/50 transition"
+                >
                   <p className="font-semibold text-[#1A2930] text-sm group-hover:text-[#FFA500] transition">
-                    {dest}
+                    {dest.label}
                   </p>
-                );
-                return href ? (
-                  <Link
-                    key={dest}
-                    href={href}
-                    className="group rounded-xl border border-gray-200 bg-[#F9FAFB] px-4 py-4 text-center hover:border-[#FFA500]/50 transition"
-                  >
-                    {inner}
-                  </Link>
-                ) : (
-                  <div
-                    key={dest}
-                    className="rounded-xl border border-gray-200 bg-[#F9FAFB] px-4 py-4 text-center"
-                  >
-                    {inner}
-                  </div>
-                );
-              },
+                </Link>
+              ) : (
+                <div
+                  key={dest.label}
+                  className="rounded-xl border border-gray-200 bg-white px-4 py-4 text-center"
+                >
+                  <p className="font-semibold text-[#1A2930] text-sm">
+                    {dest.label}
+                  </p>
+                </div>
+              )
             )}
           </div>
         </div>
@@ -344,7 +395,7 @@ export default function InstitutionalPage() {
             destination and your timeline. No obligation. No sales script.
           </p>
           <div className="flex flex-col sm:flex-row gap-4 justify-center">
-            <a
+            
               href="https://calendly.com/ellcworth/15min"
               target="_blank"
               rel="noopener noreferrer"
@@ -352,7 +403,7 @@ export default function InstitutionalPage() {
             >
               Book a 15-minute call
             </a>
-            <a
+            
               href="mailto:cs@ellcworth.com"
               className="inline-flex items-center justify-center rounded-full border border-white/30 bg-white/5 text-white px-8 py-3 text-sm font-semibold tracking-[0.14em] uppercase hover:bg-white/10 transition"
             >


### PR DESCRIPTION
- Hero and metadata broadened beyond universities/NGOs
- New 'Who We Serve' section with 6 institution types
- cargoTypes expanded: medical procurement, banking equipment, government cargo, NGO supplies
- Track record section reframed — certificates as proof of standard, not the whole story
- Stats updated: 10+ institutions across education, health and government
- Nigeria and Kenya destination cards now linked to their destination pages
- Retainer copy updated to include hospitals and banks