### PR TITLE
Fix: footer links, about mission statement, insights route accuracy

### DIFF
--- a/frontend-next/app/about/page.tsx
+++ b/frontend-next/app/about/page.tsx
@@ -200,31 +200,35 @@ export default function AboutPage() {
         </div>
       </section>
 
-      {/* Founder note */}
+      {/* Mission */}
       <section className="py-16 md:py-24 bg-white">
         <div className="mx-auto max-w-4xl px-4 md:px-6 lg:px-8">
           <span className="inline-flex items-center rounded-full bg-[#1A2930] text-[#FFA500] px-3 py-1 text-[11px] font-semibold tracking-[0.16em] uppercase mb-4">
-            Founder Note
+            Our Mission
           </span>
-          <div className="flex flex-col md:flex-row gap-8 items-start">
-            <div className="flex-shrink-0 w-32 h-32 rounded-2xl bg-[#1A2930]/10 border border-gray-200 flex items-center justify-center text-4xl">
-              👤
-            </div>
-            <div className="text-gray-700 space-y-4 text-base md:text-lg leading-relaxed">
-              <p>
-                Ellcworth Express was built on a simple belief: that businesses
-                and institutions moving cargo between the UK and West Africa
-                deserve a freight partner who understands both sides of the
-                corridor — not just the logistics, but the stakes.
-              </p>
-              <p>
-                We are not a large freight broker. We are a specialist. And that
-                specialism is what our clients rely on.
-              </p>
-              <p className="text-sm text-gray-500 italic">
-                — Founder, Ellcworth Express
-              </p>
-            </div>
+          <h2 className="text-2xl md:text-3xl font-semibold uppercase text-[#1A2930] mb-6">
+            Specialist logistics for a corridor that demands it.
+          </h2>
+          <div className="text-gray-700 space-y-5 text-base md:text-lg leading-relaxed">
+            <p>
+              Ellcworth Express exists to give businesses and institutions moving
+              cargo between the UK and West Africa a freight partner who
+              understands both sides of the corridor — not just the logistics,
+              but the stakes.
+            </p>
+            <p>
+              The UK–West Africa route is not a generic trade lane. It has its
+              own port dynamics, customs requirements, clearing agent
+              relationships and on-the-ground realities. Treating it like any
+              other corridor is how shipments go wrong. We have spent 12 years
+              learning it properly so our clients do not have to.
+            </p>
+            <p>
+              We are not a large freight broker. We are a specialist. Our
+              clients — universities, hospitals, banks, government agencies and
+              businesses — rely on that specialism when the cargo cannot afford
+              to fail.
+            </p>
           </div>
         </div>
       </section>

--- a/frontend-next/app/components/Footer.tsx
+++ b/frontend-next/app/components/Footer.tsx
@@ -8,32 +8,26 @@ const Footer = () => {
         <div className="grid gap-8 md:grid-cols-4">
           <div className="md:col-span-2">
             <Link href="/" className="flex items-center gap-3 mb-4">
-              <img
-                src="/Logo_w.svg"
-                alt="Ellcworth Express Logo"
-                className="w-12 h-auto"
-              />
+              <img src="/Logo_w.svg" alt="Ellcworth Express Logo" className="w-12 h-auto" />
               <span className="text-lg md:text-xl font-semibold tracking-tight">
                 ELLCWORTH <span className="text-[#FFA500]">EXPRESS</span>
               </span>
             </Link>
-
             <p className="text-sm md:text-[15px] text-slate-300 max-w-md leading-relaxed">
               UK–Africa shipping support for containers, vehicles, air freight
               and secure documentation – with clear communication from booking
               to delivery.
             </p>
-
             <div className="mt-5 flex flex-wrap gap-2">
-              <span className="text-[11px] px-3 py-1 rounded-full bg-white/5 border border-white/10 text-slate-300">
+              <Link href="/#services" className="text-[11px] px-3 py-1 rounded-full bg-white/5 border border-white/10 text-slate-300 hover:text-[#FFA500] hover:border-[#FFA500]/40 transition">
                 RoRo &amp; Containers
-              </span>
-              <span className="text-[11px] px-3 py-1 rounded-full bg-white/5 border border-white/10 text-slate-300">
+              </Link>
+              <Link href="/#services" className="text-[11px] px-3 py-1 rounded-full bg-white/5 border border-white/10 text-slate-300 hover:text-[#FFA500] hover:border-[#FFA500]/40 transition">
                 Air Freight
-              </span>
-              <span className="text-[11px] px-3 py-1 rounded-full bg-white/5 border border-white/10 text-slate-300">
+              </Link>
+              <Link href="/#services" className="text-[11px] px-3 py-1 rounded-full bg-white/5 border border-white/10 text-slate-300 hover:text-[#FFA500] hover:border-[#FFA500]/40 transition">
                 Secure Documents
-              </span>
+              </Link>
             </div>
           </div>
 
@@ -42,35 +36,10 @@ const Footer = () => {
               Services
             </h3>
             <ul className="space-y-2 text-sm md:text-[15px]">
-              <li>
-                <Link href="/about" className="hover:text-[#FFA500] transition">
-                  About Ellcworth
-                </Link>
-              </li>
-              <li>
-                <Link
-                  href="/#quote"
-                  className="hover:text-[#FFA500] transition"
-                >
-                  Get a shipping quote
-                </Link>
-              </li>
-              <li>
-                <Link
-                  href="/#destinations"
-                  className="hover:text-[#FFA500] transition"
-                >
-                  Destinations &amp; services
-                </Link>
-              </li>
-              <li>
-                <Link
-                  href="/#stories"
-                  className="hover:text-[#FFA500] transition"
-                >
-                  Customer stories
-                </Link>
-              </li>
+              <li><Link href="/about" className="hover:text-[#FFA500] transition">About Ellcworth</Link></li>
+              <li><Link href="/#quote" className="hover:text-[#FFA500] transition">Get a shipping quote</Link></li>
+              <li><Link href="/#services" className="hover:text-[#FFA500] transition">Destinations &amp; services</Link></li>
+              <li><Link href="/#stories" className="hover:text-[#FFA500] transition">Customer stories</Link></li>
             </ul>
           </div>
 
@@ -81,34 +50,15 @@ const Footer = () => {
             <ul className="space-y-2 text-sm md:text-[15px]">
               <li className="flex items-center gap-2">
                 <FaEnvelope className="text-[#FFA500]" />
-                <a
-                  href="mailto:info@ellcworth.com"
-                  className="hover:text-[#FFA500] transition"
-                >
-                  info@ellcworth.com
-                </a>
+                <a href="mailto:info@ellcworth.com" className="hover:text-[#FFA500] transition">info@ellcworth.com</a>
               </li>
-
               <li className="flex items-center gap-2">
                 <FaPhoneAlt className="text-[#FFA500]" />
-                <a
-                  href="tel:+442089796054"
-                  className="hover:text-[#FFA500] transition"
-                >
-                  +44 (0) 20 8979 6054
-                </a>
+                <a href="tel:+442089796054" className="hover:text-[#FFA500] transition">+44 (0) 20 8979 6054</a>
               </li>
-
               <li className="flex items-center gap-2">
                 <FaWhatsapp className="text-[#FFA500]" />
-                <a
-                  href="https://wa.me/447776234234?text=Hello%20Ellcworth%2C%20I%20have%20a%20shipping%20enquiry."
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="text-slate-300 hover:text-white transition-colors"
-                >
-                  Chat with us on WhatsApp
-                </a>
+                <a href="https://wa.me/447776234234?text=Hello%20Ellcworth%2C%20I%20have%20a%20shipping%20enquiry." target="_blank" rel="noopener noreferrer" className="text-slate-300 hover:text-white transition-colors">Chat with us on WhatsApp</a>
               </li>
             </ul>
           </div>
@@ -116,20 +66,12 @@ const Footer = () => {
 
         <div className="mt-8 border-t border-slate-800 pt-4 flex flex-col md:flex-row items-start md:items-center justify-between gap-3">
           <p className="text-xs md:text-sm text-slate-500">
-            © {new Date().getFullYear()} Ellcworth Express Ltd. All rights
-            reserved.
+            © {new Date().getFullYear()} Ellcworth Express Ltd. All rights reserved.
           </p>
-
           <div className="flex flex-wrap gap-4 text-xs md:text-sm text-slate-500">
-            <Link href="/terms" className="hover:text-[#FFA500] transition">
-              Terms &amp; conditions
-            </Link>
-            <Link href="/privacy" className="hover:text-[#FFA500] transition">
-              Privacy policy
-            </Link>
-            <Link href="/cookies" className="hover:text-[#FFA500] transition">
-              Cookies
-            </Link>
+            <Link href="/terms" className="hover:text-[#FFA500] transition">Terms &amp; conditions</Link>
+            <Link href="/privacy" className="hover:text-[#FFA500] transition">Privacy policy</Link>
+            <Link href="/cookies" className="hover:text-[#FFA500] transition">Cookies</Link>
           </div>
         </div>
       </div>

--- a/frontend-next/app/insights/uds-degree-certificates/page.tsx
+++ b/frontend-next/app/insights/uds-degree-certificates/page.tsx
@@ -78,11 +78,11 @@ export default function UDSCaseStudy() {
         <div className="space-y-4">
           <h2 className="text-white text-lg font-bold tracking-tight">The Challenge</h2>
           <p className="text-[#C8CDD6] text-sm leading-relaxed">
-            A UK printer delay and a hard graduation deadline. Ten cartons of secure-printed degree
-            certificates needed to reach the University for Development Studies in Tamale, northern
-            Ghana — 48 hours from warehouse to Heathrow, with no margin for error on the delivery
-            side. Certificates held up in transit or cleared late meant a graduation ceremony without
-            its documents.
+            Ten cartons of secure-printed degree certificates needed to reach the University for
+            Development Studies in Tamale, northern Ghana — with a hard graduation deadline and no
+            margin for error on the delivery side. The window from collection to Heathrow was tight:
+            48 hours. Certificates held up in transit or cleared late meant a graduation ceremony
+            without its documents.
           </p>
           <p className="text-[#C8CDD6] text-sm leading-relaxed">
             Secure print consignments of this kind carry institutional weight beyond their physical
@@ -98,7 +98,7 @@ export default function UDSCaseStudy() {
             Shipment Route
           </p>
           <p className="text-white text-sm font-medium">
-            Grays, Essex → Heathrow (LHR) → Accra International Airport (ACC) → UDS Tamale
+            Vendor Collection (UK) → Heathrow Air Freight Facility (LHR) → Accra International Airport (ACC) → UDS Tamale
           </p>
         </div>
 
@@ -106,8 +106,8 @@ export default function UDSCaseStudy() {
         <div className="space-y-4">
           <h2 className="text-white text-lg font-bold tracking-tight">The Operation</h2>
           <p className="text-[#C8CDD6] text-sm leading-relaxed">
-            Ellcworth collected the ten cartons directly from the printer in Grays, Essex and
-            palletised them for air freight within 48 hours. Export documentation was completed
+            Ellcworth collected the ten cartons directly from the printer and transferred them
+            to the Heathrow air freight facility, palletised and ready to move within 48 hours. Export documentation was completed
             same-day. The consignment moved through Heathrow on a direct service to Accra
             Kotoka International Airport, where Ellcworth&apos;s Ghana-side partners handled
             customs clearance end-to-end.

--- a/frontend-next/app/insights/university-of-ghana-80000-certificates/page.tsx
+++ b/frontend-next/app/insights/university-of-ghana-80000-certificates/page.tsx
@@ -99,7 +99,7 @@ export default function UniversityOfGhanaCaseStudy() {
             Shipment Route
           </p>
           <p className="text-white text-sm font-medium">
-            Hounslow Print Facility → Heathrow (LHR) → Accra International Airport (ACC) → UG Legon
+            Vendor Collection (UK) → Heathrow Air Freight Facility (LHR) → Accra International Airport (ACC) → UG Legon
           </p>
         </div>
 
@@ -107,11 +107,11 @@ export default function UniversityOfGhanaCaseStudy() {
         <div className="space-y-4">
           <h2 className="text-white text-lg font-bold tracking-tight">The Operation</h2>
           <p className="text-[#C8CDD6] text-sm leading-relaxed">
-            Ellcworth collected directly from the print facility in Hounslow — a short drive
-            from Heathrow that eliminated an unnecessary warehousing leg. Photographic proof
-            of collection was issued to the UG liaison contact at point of pickup. Export
-            documentation and proof of export were completed before the pallets left the
-            facility.
+            Ellcworth collected directly from the print facility and transferred the pallets
+            to the Heathrow air freight facility — eliminating any unnecessary warehousing leg.
+            Photographic proof of collection was issued to the UG liaison contact at point of
+            pickup. Export documentation and proof of export were completed before the pallets
+            left the vendor.
           </p>
           <p className="text-[#C8CDD6] text-sm leading-relaxed">
             The consignment moved on a direct LHR–ACC service. Live tracking updates were


### PR DESCRIPTION
- Footer service badges now link to /#services
- About page: founder note replaced with company mission statement
- UDS article: removed printer blame framing, route updated to vendor-agnostic
- UG article: Hounslow reference removed, route updated to vendor-agnostic