### PR TITLE
fix: reset shipment notification flag on status change

### DIFF
--- a/Backend/controllers/shipment.js
+++ b/Backend/controllers/shipment.js
@@ -1367,6 +1367,9 @@ async function updateStatus(req, res) {
 
     shipment.status = status;
 
+    if (!shipment.notifications) shipment.notifications = {};
+    shipment.notifications[status] = false;
+
     shipment.trackingEvents.push({
       status,
       event:


### PR DESCRIPTION
updateStatus now resets notifications[status]=false so the background cron picks up the new status and fires the milestone email.