### PR TITLE
seo: metadata fixes, robots.txt, sitemap, openGraph

### DIFF
--- a/frontend-next/app/components/ServicesClient.tsx
+++ b/frontend-next/app/components/ServicesClient.tsx
@@ -65,7 +65,7 @@ const SERVICES = [
     highlights: [
       "Deadline rescue service",
       "End-to-end ownership",
-      "12 years · zero failures",
+      "15+ years · zero failures",
     ],
     bestFor:
       "Universities, examination bodies and organisations moving time-critical cargo when the window is already tight.",

--- a/frontend-next/app/destinations/cote-divoire/page.tsx
+++ b/frontend-next/app/destinations/cote-divoire/page.tsx
@@ -5,6 +5,15 @@ export const metadata: Metadata = {
   title: "Shipping to Côte d'Ivoire from the UK | Container & Air Freight | Ellcworth Express",
   description: "FCL container shipping and air freight from the UK to Côte d'Ivoire. Abidjan Port Autonome and Félix Houphouët-Boigny International Airport. Full customs clearance end-to-end.",
   alternates: { canonical: "https://www.ellcworth.com/destinations/cote-divoire" },
+  openGraph: {
+    title: "Shipping to Côte d'Ivoire from the UK | Container & Air Freight | Ellcworth Express",
+    description: "FCL container shipping and air freight from the UK to Côte d'Ivoire. Abidjan Port Autonome and Félix Houphouët-Boigny International Airport. Full customs clearance end-to-end.",
+    url: "https://www.ellcworth.com/destinations/cote-divoire",
+    siteName: "Ellcworth Express",
+    type: "website",
+    images: [{ url: "https://www.ellcworth.com/ellc_hero1.png" }],
+  },
+  twitter: { card: "summary_large_image", title: "Shipping to Côte d'Ivoire from the UK | Ellcworth Express", description: "FCL container shipping and air freight UK to Côte d'Ivoire. Abidjan Port Autonome. Full customs clearance end-to-end." },
 };
 
 const STATS = [

--- a/frontend-next/app/destinations/ghana/page.tsx
+++ b/frontend-next/app/destinations/ghana/page.tsx
@@ -5,6 +5,15 @@ export const metadata: Metadata = {
   title: "Shipping to Ghana from the UK | Container, RoRo & Air Freight | Ellcworth Express",
   description: "Container shipping, RoRo vehicle shipping and air freight from the UK to Ghana. Tema Port and Accra International Airport. ICUMS customs clearance end-to-end.",
   alternates: { canonical: "https://www.ellcworth.com/destinations/ghana" },
+  openGraph: {
+    title: "Shipping to Ghana from the UK | Container, RoRo & Air Freight | Ellcworth Express",
+    description: "Container shipping, RoRo vehicle shipping and air freight from the UK to Ghana. Tema Port and Accra International Airport. ICUMS customs clearance end-to-end.",
+    url: "https://www.ellcworth.com/destinations/ghana",
+    siteName: "Ellcworth Express",
+    type: "website",
+    images: [{ url: "https://www.ellcworth.com/ellc_hero1.png" }],
+  },
+  twitter: { card: "summary_large_image", title: "Shipping to Ghana from the UK | Ellcworth Express", description: "Container shipping, RoRo and air freight UK to Ghana. Tema Port and Accra Airport. ICUMS clearance end-to-end." },
 };
 
 export default function GhanaPage() {

--- a/frontend-next/app/destinations/kenya/page.tsx
+++ b/frontend-next/app/destinations/kenya/page.tsx
@@ -5,6 +5,15 @@ export const metadata: Metadata = {
   title: "Shipping to Kenya from the UK | Container & Air Freight | Ellcworth Express",
   description: "FCL container shipping and air freight from the UK to Kenya. Mombasa Port and Jomo Kenyatta International Airport. Export documentation and customs clearance end-to-end.",
   alternates: { canonical: "https://www.ellcworth.com/destinations/kenya" },
+  openGraph: {
+    title: "Shipping to Kenya from the UK | Container & Air Freight | Ellcworth Express",
+    description: "FCL container shipping and air freight from the UK to Kenya. Mombasa Port and Jomo Kenyatta International Airport. Export documentation and customs clearance end-to-end.",
+    url: "https://www.ellcworth.com/destinations/kenya",
+    siteName: "Ellcworth Express",
+    type: "website",
+    images: [{ url: "https://www.ellcworth.com/ellc_hero1.png" }],
+  },
+  twitter: { card: "summary_large_image", title: "Shipping to Kenya from the UK | Ellcworth Express", description: "FCL container shipping and air freight UK to Kenya. Mombasa Port and Nairobi Airport. Customs clearance end-to-end." },
 };
 
 const STATS = [

--- a/frontend-next/app/destinations/nigeria/page.tsx
+++ b/frontend-next/app/destinations/nigeria/page.tsx
@@ -5,6 +5,15 @@ export const metadata: Metadata = {
   title: "Shipping to Nigeria from the UK | Container & Air Freight | Ellcworth Express",
   description: "FCL container shipping and air freight from the UK to Nigeria. Apapa Port Lagos and Murtala Muhammed Airport. Export documentation, customs clearance end-to-end.",
   alternates: { canonical: "https://www.ellcworth.com/destinations/nigeria" },
+  openGraph: {
+    title: "Shipping to Nigeria from the UK | Container & Air Freight | Ellcworth Express",
+    description: "FCL container shipping and air freight from the UK to Nigeria. Apapa Port Lagos and Murtala Muhammed Airport. Export documentation, customs clearance end-to-end.",
+    url: "https://www.ellcworth.com/destinations/nigeria",
+    siteName: "Ellcworth Express",
+    type: "website",
+    images: [{ url: "https://www.ellcworth.com/ellc_hero1.png" }],
+  },
+  twitter: { card: "summary_large_image", title: "Shipping to Nigeria from the UK | Ellcworth Express", description: "FCL container shipping and air freight UK to Nigeria. Apapa Port Lagos. Export documentation end-to-end." },
 };
 
 const STATS = [

--- a/frontend-next/app/destinations/sierra-leone/page.tsx
+++ b/frontend-next/app/destinations/sierra-leone/page.tsx
@@ -5,6 +5,15 @@ export const metadata: Metadata = {
   title: "Shipping to Sierra Leone from the UK | Container & Air Freight | Ellcworth Express",
   description: "FCL container shipping and air freight from the UK to Sierra Leone. Freetown Queen Elizabeth II Quay and Lungi International Airport. Full customs clearance end-to-end.",
   alternates: { canonical: "https://www.ellcworth.com/destinations/sierra-leone" },
+  openGraph: {
+    title: "Shipping to Sierra Leone from the UK | Container & Air Freight | Ellcworth Express",
+    description: "FCL container shipping and air freight from the UK to Sierra Leone. Freetown Queen Elizabeth II Quay and Lungi International Airport. Full customs clearance end-to-end.",
+    url: "https://www.ellcworth.com/destinations/sierra-leone",
+    siteName: "Ellcworth Express",
+    type: "website",
+    images: [{ url: "https://www.ellcworth.com/ellc_hero1.png" }],
+  },
+  twitter: { card: "summary_large_image", title: "Shipping to Sierra Leone from the UK | Ellcworth Express", description: "FCL container shipping and air freight UK to Sierra Leone. Freetown QEII Quay and Lungi Airport. Full customs clearance." },
 };
 
 const STATS = [

--- a/frontend-next/app/insights/page.tsx
+++ b/frontend-next/app/insights/page.tsx
@@ -6,6 +6,15 @@ export const metadata: Metadata = {
   description:
     "Real freight operations from Ellcworth Express — air freight case studies, customs intelligence, and trade guides for UK exporters shipping to Ghana and West Africa.",
   alternates: { canonical: "https://www.ellcworth.com/insights" },
+  openGraph: {
+    title: "Insights & Case Studies | Ellcworth Express",
+    description: "Real freight operations from Ellcworth Express — air freight case studies, customs intelligence, and trade guides for UK exporters shipping to Ghana and West Africa.",
+    url: "https://www.ellcworth.com/insights",
+    siteName: "Ellcworth Express",
+    type: "website",
+    images: [{ url: "https://www.ellcworth.com/ellc_hero1.png" }],
+  },
+  twitter: { card: "summary_large_image", title: "Insights & Case Studies | Ellcworth Express", description: "Real freight operations — air freight case studies, customs intelligence, and trade guides for UK exporters shipping to West Africa." },
 };
 
 const caseStudies = [

--- a/frontend-next/app/institutional/page.tsx
+++ b/frontend-next/app/institutional/page.tsx
@@ -7,7 +7,7 @@ export const metadata: Metadata = {
   alternates: { canonical: "https://www.ellcworth.com/institutional" },
   openGraph: {
     title: "Institutional Cargo UK to Africa | Ellcworth Express",
-    description: "Ellcworth Express ships for universities, hospitals, banks, government ministries and NGOs — sealed, documented, on time. 12 years. Zero institutional deadlines missed.",
+    description: "Ellcworth Express ships for universities, hospitals, banks, government ministries and NGOs — sealed, documented, on time. 15+ years. Zero institutional deadlines missed.",
     url: "https://www.ellcworth.com/institutional",
     type: "website",
     images: [{ url: "https://www.ellcworth.com/ellc_hero1.png" }],
@@ -15,12 +15,12 @@ export const metadata: Metadata = {
   twitter: {
     card: "summary_large_image",
     title: "Institutional Cargo UK to Africa | Ellcworth Express",
-    description: "Ellcworth Express ships for universities, hospitals, banks, government ministries and NGOs — sealed, documented, on time. 12 years. Zero institutional deadlines missed.",
+    description: "Ellcworth Express ships for universities, hospitals, banks, government ministries and NGOs — sealed, documented, on time. 15+ years. Zero institutional deadlines missed.",
   },
 };
 
 const cargoTypes = [
-  { icon: "🎓", title: "Academic & ceremonial cargo", body: "Blank degree certificates, regalia and academic materials. Tamper-proof, time-critical. Collected from UK printers, sealed and delivered to campus before graduation. We have never missed a deadline in 12 years." },
+  { icon: "🎓", title: "Academic & ceremonial cargo", body: "Blank degree certificates, regalia and academic materials. Tamper-proof, time-critical. Collected from UK printers, sealed and delivered to campus before graduation. We have never missed a deadline in 15+ years." },
   { icon: "🏥", title: "Medical & healthcare procurement", body: "Hospital equipment, diagnostic devices, pharmaceutical supplies and consumables for healthcare procurement agencies. Handled with the documentation discipline that institutional supply chains demand." },
   { icon: "🏦", title: "Banking & financial equipment", body: "ATM units, cash-handling equipment, server infrastructure and secure IT hardware for banks and financial institutions. Chain-of-custody documentation provided at every stage." },
   { icon: "🏛️", title: "Government & ministry cargo", body: "Ministerial procurement, civil service equipment and public sector project cargo. We work within formal procurement frameworks — proper invoices, auditable documentation, named contacts." },
@@ -104,9 +104,9 @@ export default function InstitutionalPage() {
           <span className="inline-flex items-center rounded-full bg-[#1A2930] text-[#FFA500] px-3 py-1 text-[11px] font-semibold tracking-[0.16em] uppercase mb-4">Track Record</span>
           <h2 className="text-2xl md:text-3xl font-semibold uppercase text-[#1A2930] mb-6">Graduation is 7 days away.<br />There is no room for error.</h2>
           <div className="text-gray-700 space-y-5 text-base md:text-lg leading-relaxed mb-12">
-            <p>For over 12 years, Ellcworth Express has been the logistics partner behind some of Ghana's most important graduation ceremonies. Each year, universities across Ghana — including the University of Ghana, KNUST, UCC and UDS — outsource the printing of their blank degree certificates to specialist printers in the UK.</p>
+            <p>For over 15 years, Ellcworth Express has been the logistics partner behind some of Ghana's most important graduation ceremonies. Each year, universities across Ghana — including the University of Ghana, KNUST, UCC and UDS — outsource the printing of their blank degree certificates to specialist printers in the UK.</p>
             <p>By the time we receive the call, graduation is typically 7 days away. The certificates must be collected, packaged tamper-proof, cleared through UK export and Ghana customs, and delivered to campus before the ceremony begins.</p>
-            <p className="font-semibold text-[#1A2930]">In 12 years, we have never let a single institution down.</p>
+            <p className="font-semibold text-[#1A2930]">In 15+ years, we have never let a single institution down.</p>
             <p>That track record extends beyond academia. The same process — sealed, documented, tracked, delivered — is what hospitals, procurement agencies and government ministries get when they ship with us. The cargo changes. The standard does not.</p>
           </div>
           <div className="grid grid-cols-1 sm:grid-cols-3 gap-6">

--- a/frontend-next/app/layout.tsx
+++ b/frontend-next/app/layout.tsx
@@ -17,7 +17,7 @@ const montserrat = Montserrat({
 });
 
 export const metadata: Metadata = {
-  metadataBase: new URL("https://ellcworth.com"),
+  metadataBase: new URL("https://www.ellcworth.com"),
   title: {
     default: "Ellcworth Express | UK to Ghana Freight & Shipping Specialists",
     template: "%s | Ellcworth Express",

--- a/frontend-next/app/page.tsx
+++ b/frontend-next/app/page.tsx
@@ -29,11 +29,11 @@ const jsonLd = {
 
 export const metadata: Metadata = {
   title: "UK to Ghana Freight Forwarder | Ellcworth Express",
-  description: "12 years shipping containers, vehicles and sensitive cargo from the UK to Ghana, Nigeria and West Africa. Sealed, documented, on time.",
+  description: "15+ years shipping containers, vehicles and sensitive cargo from the UK to Ghana, Nigeria and West Africa. Sealed, documented, on time.",
   alternates: { canonical: "https://www.ellcworth.com/" },
   openGraph: {
     title: "UK to Ghana Freight Forwarder | Ellcworth Express",
-    description: "12 years shipping containers, vehicles and sensitive cargo from the UK to Ghana, Nigeria and West Africa. Sealed, documented, on time.",
+    description: "15+ years shipping containers, vehicles and sensitive cargo from the UK to Ghana, Nigeria and West Africa. Sealed, documented, on time.",
     url: "https://www.ellcworth.com/",
     type: "website",
     images: [{ url: "https://www.ellcworth.com/ellc_hero1.png" }],
@@ -41,7 +41,7 @@ export const metadata: Metadata = {
   twitter: {
     card: "summary_large_image",
     title: "UK to Ghana Freight Forwarder | Ellcworth Express",
-    description: "12 years shipping containers, vehicles and sensitive cargo from the UK to Ghana, Nigeria and West Africa. Sealed, documented, on time.",
+    description: "15+ years shipping containers, vehicles and sensitive cargo from the UK to Ghana, Nigeria and West Africa. Sealed, documented, on time.",
   },
 };
 

--- a/frontend-next/app/services/[id]/page.tsx
+++ b/frontend-next/app/services/[id]/page.tsx
@@ -38,7 +38,7 @@ const SEO: Record<string, { title: string; desc: string }> = {
   },
   jit: {
     title: "Just In Time (JIT) Delivery UK to Ghana | Ellcworth Express",
-    desc: "Dedicated time-critical air freight for graduation certificates and high-integrity cargo. 12 years. Zero failures. UK to Ghana.",
+    desc: "Dedicated time-critical air freight for graduation certificates and high-integrity cargo. 15+ years. Zero failures. UK to Ghana.",
   },
   customs: {
     title: "Export & Customs Support UK to West Africa | Ellcworth Express",
@@ -102,7 +102,7 @@ export default async function ServiceDetailPage({ params }: Props) {
             <div className="mt-4 rounded-3xl border border-white/10 bg-[#0B1118] p-6 md:p-8">
               <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-[#FFA500] mb-4">How JIT Came About</p>
               <div className="space-y-4 text-gray-300 leading-relaxed">
-                <p>Ellcworth Express has been handling exactly this consignment — for exactly this deadline — for over 12 years. What began as a single urgent assignment became a repeat engagement. Then a pattern. Then a process refined over a decade of not once missing a graduation deadline.</p>
+                <p>Ellcworth Express has been handling exactly this consignment — for exactly this deadline — for over 15 years. What began as a single urgent assignment became a repeat engagement. Then a pattern. Then a process refined over a decade of not once missing a graduation deadline.</p>
                 <p>JIT was not designed in a boardroom. It was built in the field, shaped by the real pressures procurement directors face every year — and by our absolute refusal to let any one of them down.</p>
                 <p>When you hand a JIT consignment to Ellcworth, the deadline transfers with it. It becomes our problem to solve — and our record to protect.</p>
               </div>

--- a/frontend-next/app/sitemap.ts
+++ b/frontend-next/app/sitemap.ts
@@ -1,0 +1,24 @@
+import { MetadataRoute } from "next";
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  const base = "https://www.ellcworth.com";
+  const now = new Date();
+
+  return [
+    { url: `${base}/`,                                                 lastModified: now, changeFrequency: "weekly",  priority: 1.0 },
+    { url: `${base}/about`,                                            lastModified: now, changeFrequency: "monthly", priority: 0.8 },
+    { url: `${base}/institutional`,                                    lastModified: now, changeFrequency: "monthly", priority: 0.8 },
+    { url: `${base}/insights`,                                         lastModified: now, changeFrequency: "weekly",  priority: 0.7 },
+    { url: `${base}/insights/uds-degree-certificates`,                lastModified: now, changeFrequency: "monthly", priority: 0.7 },
+    { url: `${base}/insights/university-of-ghana-80000-certificates`, lastModified: now, changeFrequency: "monthly", priority: 0.7 },
+    { url: `${base}/destinations/ghana`,                               lastModified: now, changeFrequency: "monthly", priority: 0.9 },
+    { url: `${base}/destinations/nigeria`,                             lastModified: now, changeFrequency: "monthly", priority: 0.9 },
+    { url: `${base}/destinations/kenya`,                               lastModified: now, changeFrequency: "monthly", priority: 0.8 },
+    { url: `${base}/destinations/sierra-leone`,                       lastModified: now, changeFrequency: "monthly", priority: 0.7 },
+    { url: `${base}/destinations/cote-divoire`,                       lastModified: now, changeFrequency: "monthly", priority: 0.7 },
+    { url: `${base}/services`,                                         lastModified: now, changeFrequency: "monthly", priority: 0.8 },
+    { url: `${base}/privacy`,                                          lastModified: now, changeFrequency: "yearly",  priority: 0.3 },
+    { url: `${base}/terms`,                                            lastModified: now, changeFrequency: "yearly",  priority: 0.3 },
+    { url: `${base}/cookies`,                                          lastModified: now, changeFrequency: "yearly",  priority: 0.3 },
+  ];
+}

--- a/frontend-next/public/robots.txt
+++ b/frontend-next/public/robots.txt
@@ -1,3 +1,11 @@
 User-agent: *
 Allow: /
+
+Disallow: /login
+Disallow: /myshipments
+Disallow: /newbooking
+Disallow: /editbooking
+Disallow: /shipmentdetails
+Disallow: /auth/
+
 Sitemap: https://www.ellcworth.com/sitemap.xml


### PR DESCRIPTION
15+ years throughout all pages and metadata (was 12). metadataBase aligned to www. robots.txt blocks auth pages. sitemap.ts covers all public pages. openGraph added to destination and insights pages.